### PR TITLE
Added partial request printing functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ If you are not familiar with GraphQL syntax, We recommended to read on this [spe
     /*
     * Result: {"query": "query {\nnotes {\nid\ncreatedDate\ncontent\nauthor {\nname\navatarUrl(size: 100)\n}\n}\n}", "variables": null, "operationName": null}
     */
-    println(query.toGrapQueryString())
+    println(query.toGraphQueryString())
     /*
     * Result: 
     * query {

--- a/README.md
+++ b/README.md
@@ -255,7 +255,8 @@ First, let's see what Kraph provides for you.
     which are sometimes necessary depending on your HTTP request builder and
     GraphQL server setup. They provide the values for the `query`, `variables`,
     and `operationName` parameters, respectively, and so are good for creating
-    GET requests.
+    GET requests. Please note that `requestVariableString()` will always return
+    `null` until variable support is implemented.
 
 ### Contributing to Kraph
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,42 @@ First, let's see what Kraph provides for you.
     }
     ```
 
+-   `fragment` provides a mechanism for creating GraphQL Fragments. To use a fragment
+    in a query requires two steps. The first is to define the fragment, letting
+    Kraph know how to handle it later:
+    ```graphql
+    fragment UserFragment on User {
+      name
+      email
+      avatarUrl(size: 100)
+    }
+    ```
+    ```kotlin
+    Kraph.fragment("UserFragment") {
+        field("name")
+        field("email")
+        field("avatarUrl", mapOf("size" to 100))
+    }
+    ```
+    Then, when you are creating your query, you can simply use the fragment and
+    its fields will be expanded:
+    ```graphql
+    query {
+      users {
+        ...UserFragment
+      }
+    }
+    ```
+    ```kotlin
+    Kraph {
+        query("GetUsers") {
+            fieldObject("users") {
+                fragment("UserFragment")
+            }
+        }
+    }
+    ```
+
 #### Relay
 
 -   `func` represents a Field inside a Mutation block that follows the

--- a/README.md
+++ b/README.md
@@ -250,6 +250,11 @@ First, let's see what Kraph provides for you.
      * }
      */
     ```
+-   `requestQueryString()`, `requestVariableString()` and `requestOperationName()`
+    provide more fine grained access to the components of the full request string,
+    which are sometimes necessary depending on your HTTP request builder and
+    GraphQL server setup. They provide the values for the `query`, `variables`,
+    and `operationName` parameters, respectively.
 
 ### Contributing to Kraph
 

--- a/README.md
+++ b/README.md
@@ -96,8 +96,9 @@ First, let's see what Kraph provides for you.
         }
     }
     ```
--   `field` and `fieldObject` represent accessors for fields. The difference is
-    that `fieldObject`s can contain nested `field` and `fieldObject` queries.
+-   `field` and `fieldObject` represent accessors for fields. Though there are
+    technically no differences, `fieldObject` may be chosen for clarity to indicate
+    that a field must contain another set of nested fields as an argument.
     Both of them take a `Map<String, Any>` that maps Kotlin data types to the
     GraphQL data types for input objects.
     ```graphql

--- a/README.md
+++ b/README.md
@@ -1,95 +1,115 @@
 # Kraph [![Build Status](https://travis-ci.org/VerachadW/kraph.svg?branch=master)](https://travis-ci.org/VerachadW/kraph) [ ![Download](https://api.bintray.com/packages/verachadw/maven/kraph/images/download.svg) ](https://bintray.com/tw/maven/kraph/_latestVersion) [![codecov](https://codecov.io/gh/VerachadW/kraph/branch/master/graph/badge.svg)](https://codecov.io/gh/VerachadW/kraph)
-In short, this is a GraphQL request JSON body builder for Kotlin. It will generate the JSON string for request body that work with GraphQL Server. For example, we have the GraphQL query for list all the notes.
-```
-    query {
-        notes {
-            id
-            createdDate
-            content
-            author {
-                name
-                avatarUrl(size: 100)
-            }
+
+In short, this is a GraphQL request JSON body builder for Kotlin. It will
+generate the JSON string for request body that work with GraphQL Server.
+For example, we have this GraphQL query to list all notes:
+```graphql
+query {
+    notes {
+        id
+        createdDate
+        content
+        author {
+            name
+            avatarUrl(size: 100)
         }
     }
+}
 ```
-And here is how we write it in Kotlin using Kraph.
+
+Which is written in Kotlin using Kraph like this:
 ```kotlin
-    Kraph {
-        query {
-            fieldObject("notes") {
-                field("id")
-                field("createdDate")
-                field("content")
-                fieldObject("author") {
-                    field("name")
-                    field("avatarUrl", mapOf("size" to 100))
-                }
+Kraph {
+    query {
+        fieldObject("notes") {
+            field("id")
+            field("createdDate")
+            field("content")
+            fieldObject("author") {
+                field("name")
+                field("avatarUrl", mapOf("size" to 100))
             }
         }
     }
+}
 ```
 As you can see, we can achieve our goal with just a few tweaks from the original query.
 
 **NOTE:** Kraph is still in an early stage. The usage may change in further development.
 
 ### Features
-- DSL builder style. Make it easier to read and use.
-- Support Cursor Connection and Input object Mutation in Relay.
+
+-   DSL builder style. Make it easier to read and use.
+-   Support Cursor Connection and Input Object Mutation in Relay.
 
 ### Set up
+
 Adding Kraph to `build.gradle`
-```kotlin
-    repositories {
-        jcenter()
-    }
-    
-    dependencies {
-        compile "me.lazmaid.kraph:kraph:x.y.z"
-    }
+```gradle
+repositories {
+    jcenter()
+}
+
+dependencies {
+    compile "me.lazmaid.kraph:kraph:x.y.z"
+}
 ```
 
 ### Guide
-If you are not familiar with GraphQL syntax, We recommended to read on this [specification](https://facebook.github.io/graphql/) to have an overview of how to write Graphql. Usually, you should be able to use the query from other tools(e.g. [GraphiQL](https://github.com/graphql/graphiql)) with a few tweaks. First, let's see what Kraph provided for you.
+
+If you are not familiar with GraphQL syntax, it is recommended to read the
+[GraphQL introduction](http://graphql.org/learn/) for an overview of how Graphql
+works. Usually, you should be able to use queries from other tools (e.g.
+[GraphiQL](https://github.com/graphql/graphiql)) with a few tweaks.
+First, let's see what Kraph provides for you.
+
 #### Simple GraphQL
-- `query`/`mutation` represents QUERY and MUTATION operation in GraphQL. It can be named by passing String as a parameter. 
-```kotlin
-    /*
-    * query GetUsers {
-    *   ...
-    * }
-    */
-    
+
+-   `query` and `mutation` represents the Query and Mutation operations of GraphQL.
+    The name of the query or mutaton can be passed as a string.
+
+    GraphQL:
+    ```graphql
+    query GetUsers {
+      ...
+    }
+    ```
+    Kraph:
+    ```kotlin
     Kraph {
         query("GetUsers") {
             ...
         }
     }
-    
-    /*
-    * mutation updateUserProfile {
-    *   ...
-    * }
-    */
-    
+    ```
+    GraphQL:
+    ```graphql
+    mutation UpdateUserProfile {
+      ...
+    }
+    ```
+    Kraph:
+    ```kotlin
     Kraph {
         mutation("UpdateUserProfile") {
-            ... 
+            ...
         }
     }
-```
-- `field` and `fieldObject` represents FIELD in SELECTION SET. The different is that `fieldObject` allow you to have it owns SELECTION SET, which represent data object in GraphQL. Both of them have a parameter named `args` for arguments in paritcular field.
-```kotlin
-    /*
-    * query {
-    *   users {
-    *       name
-    *       email
-    *       avatarUrl(size: 100)
-    *   }
-    * }
-    */
-    
+    ```
+-   `field` and `fieldObject` represent accessors for fields. The difference is
+    that `fieldObject`s can contain nested `field` and `fieldObject` queries.
+    Both of them take a `Map<String, Any>` that maps Kotlin data types to the
+    GraphQL data types for input objects.
+    ```graphql
+    query {
+      users {
+        name
+        email
+        avatarUrl(size: 100)
+      }
+    }
+    ```
+    ```kotlin
     Kraph {
         query {
             fieldObject("users") {
@@ -99,22 +119,24 @@ If you are not familiar with GraphQL syntax, We recommended to read on this [spe
             }
         }
     }
-```
+    ```
+
 #### Relay
-- `func` represents as FIELD inside MUTATION block that follow [Relay Input Object Mutations](https://facebook.github.io/relay/graphql/mutations.htm) specification.
-```kotlin
-    /*
-    * mutation {
-    *   userLogin(input: {email: "hello@taskworld.com", password: "abcd1234"}) {
-    *       accessToken
-    *       user {
-    *           id
-    *           email
-    *       }
-    *   }
-    * }
-    */
-    
+
+-   `func` represents a Field inside a Mutation block that follows the
+    [Relay Input Object Mutations](https://facebook.github.io/relay/graphql/mutations.htm) specification.
+    ```graphql
+    mutation {
+      userLogin(input: {email: "hello@taskworld.com", password: "abcd1234"}) {
+        accessToken
+        user {
+          id
+          email
+        }
+      }
+    }
+    ```
+    ```kotlin
     Kraph {
         mutation {
             func("userLogin", input = mapOf("email" to "hello@taskworld.com", "password" to "abcd1234")) {
@@ -126,22 +148,22 @@ If you are not familiar with GraphQL syntax, We recommended to read on this [spe
             }
         }
     }
-```
-- `cursorConnection` represents as FIELD that follow [Relay Cursor Connections](https://facebook.github.io/relay/graphql/connections.htm) specification
-```kotlin
-    /*
-    * query {
-    *   users(first: 10, after: "user::1234") {
-    *       edges {
-    *           node {
-    *               id
-    *               name
-    *           }
-    *       }
-    *   }
-    * }
-    */
-    
+    ```
+-   `cursorConnection` represents a Field that follows the
+    [Relay Cursor Connections](https://facebook.github.io/relay/graphql/connections.htm) specification
+    ```graphql
+    query {
+       users(first: 10, after: "user::1234") {
+        edges {
+          node {
+            id
+            name
+          }
+        }
+      }
+    }
+    ```
+    ```kotlin
     Kraph {
         cursorConnection("users", first = 10, after = "user::1234") {   
             edges {
@@ -152,11 +174,14 @@ If you are not familiar with GraphQL syntax, We recommended to read on this [spe
             }
         }
     }
-```
+    ```
+
 #### Request/Query String
-- `toRequestString()` is used for generating request JSON body for POST method.
-- `toGraphQueryString()` will give you the formatted GraphQuery string. This is very useful for debugging.
-```kotlin
+
+-   `toRequestString()` will generate a JSON body to send in POST request.
+-   `toGraphQueryString()` will give you the formatted GraphQL string. This is
+    very useful for debugging.
+    ```kotlin
     val query = Kraph {
         query {
             fieldObject("users") {
@@ -166,26 +191,30 @@ If you are not familiar with GraphQL syntax, We recommended to read on this [spe
             }
         }
     }    
-    
+
     println(query.toRequestString())
     /*
-    * Result: {"query": "query {\nnotes {\nid\ncreatedDate\ncontent\nauthor {\nname\navatarUrl(size: 100)\n}\n}\n}", "variables": null, "operationName": null}
-    */
+     * Result:
+     * {"query": "query {\nnotes {\nid\ncreatedDate\ncontent\nauthor {\nname\navatarUrl(size: 100)\n}\n}\n}", "variables": null, "operationName": null}
+     */
     println(query.toGraphQueryString())
     /*
-    * Result: 
-    * query {
-    *   notes {
-    *     id
-    *     createdDate
-    *     content
-    *     author {
-    *       name
-    *       avatarUrl(size: 100)
-    *     }
-    *   }
-    * }
-    */
-```
+     * Result:
+     * query {
+     *   notes {
+     *     id
+     *     createdDate
+     *     content
+     *     author {
+     *       name
+     *       avatarUrl(size: 100)
+     *     }
+     *   }
+     * }
+     */
+    ```
+
 ### Contributing to Kraph
-We use Github issues for tracking bugs and requests. Any feedback and/or PRs is welcome.
+
+We use Github issues for tracking bugs and requests.
+Any feedback and/or PRs is welcome.

--- a/README.md
+++ b/README.md
@@ -254,7 +254,8 @@ First, let's see what Kraph provides for you.
     provide more fine grained access to the components of the full request string,
     which are sometimes necessary depending on your HTTP request builder and
     GraphQL server setup. They provide the values for the `query`, `variables`,
-    and `operationName` parameters, respectively.
+    and `operationName` parameters, respectively, and so are good for creating
+    GET requests.
 
 ### Contributing to Kraph
 

--- a/core/src/main/kotlin/me/lazmaid/kraph/Kraph.kt
+++ b/core/src/main/kotlin/me/lazmaid/kraph/Kraph.kt
@@ -48,8 +48,8 @@ class Kraph(f: Kraph.() -> Unit) {
             addField(name, args, builder)
         }
 
-        fun field(name: String, args: Map<String, Any>? = null) {
-            addField(name, args)
+        fun field(name: String, args: Map<String, Any>? = null, builder: FieldBlock? = null) {
+            addField(name, args, builder)
         }
 
         fun cursorConnection(name: String, first: Int = -1, last: Int = -1,
@@ -109,5 +109,3 @@ class Kraph(f: Kraph.() -> Unit) {
     }
 
 }
-
-

--- a/core/src/main/kotlin/me/lazmaid/kraph/Kraph.kt
+++ b/core/src/main/kotlin/me/lazmaid/kraph/Kraph.kt
@@ -41,6 +41,10 @@ class Kraph(f: Kraph.() -> Unit) {
     fun toGraphQueryString() = document.operation.print(true, 0)
     fun toRequestString() = document.print(false, 0)
 
+    fun requestQueryString() = document.operation.print(false, 0)
+    fun requestVariableString() = document.variables.print()
+    fun requestOperationName() = document.operation.printName()
+
     inner open class FieldBuilder {
         internal val fields = arrayListOf<Field>()
 

--- a/core/src/main/kotlin/me/lazmaid/kraph/Kraph.kt
+++ b/core/src/main/kotlin/me/lazmaid/kraph/Kraph.kt
@@ -38,10 +38,10 @@ class Kraph(f: Kraph.() -> Unit) {
         return set
     }
 
-    fun toGraphQueryString() = document.operation.print(true, false, 0)
-    fun toRequestString() = document.print(false, true, 0)
+    fun toGraphQueryString() = document.operation.print(PrintFormat.PRETTY, 0)
+    fun toRequestString() = document.print(PrintFormat.JSON, 0)
 
-    fun requestQueryString() = document.operation.print(false, false, 0)
+    fun requestQueryString() = document.operation.print(PrintFormat.NORMAL, 0)
     fun requestVariableString() = document.variables.print()
     fun requestOperationName() = document.operation.name
 

--- a/core/src/main/kotlin/me/lazmaid/kraph/Kraph.kt
+++ b/core/src/main/kotlin/me/lazmaid/kraph/Kraph.kt
@@ -38,12 +38,12 @@ class Kraph(f: Kraph.() -> Unit) {
         return set
     }
 
-    fun toGraphQueryString() = document.operation.print(true, 0)
-    fun toRequestString() = document.print(false, 0)
+    fun toGraphQueryString() = document.operation.print(true, false, 0)
+    fun toRequestString() = document.print(false, true, 0)
 
-    fun requestQueryString() = document.operation.print(false, 0)
+    fun requestQueryString() = document.operation.print(false, false, 0)
     fun requestVariableString() = document.variables.print()
-    fun requestOperationName() = document.operation.printName()
+    fun requestOperationName() = document.operation.name
 
     inner open class FieldBuilder {
         internal val fields = arrayListOf<Field>()

--- a/core/src/main/kotlin/me/lazmaid/kraph/lang/Argument.kt
+++ b/core/src/main/kotlin/me/lazmaid/kraph/lang/Argument.kt
@@ -5,7 +5,11 @@ package me.lazmaid.kraph.lang
  */
 
 internal open class Argument(internal val args: Map<String, Any> = mapOf()) : GraphQLNode() {
-    override fun print(prettyFormat: Boolean, previousLevel: Int): String {
-        return "(${print(args, prettyFormat)})"
+    override fun print(
+        prettyFormat: Boolean,
+        escapeStrings: Boolean,
+        previousLevel: Int
+    ): String {
+        return "(${print(args, prettyFormat, escapeStrings)})"
     }
 }

--- a/core/src/main/kotlin/me/lazmaid/kraph/lang/Argument.kt
+++ b/core/src/main/kotlin/me/lazmaid/kraph/lang/Argument.kt
@@ -6,10 +6,9 @@ package me.lazmaid.kraph.lang
 
 internal open class Argument(internal val args: Map<String, Any> = mapOf()) : GraphQLNode() {
     override fun print(
-        prettyFormat: Boolean,
-        escapeStrings: Boolean,
+        format: PrintFormat,
         previousLevel: Int
     ): String {
-        return "(${print(args, prettyFormat, escapeStrings)})"
+        return "(${print(args, format)})"
     }
 }

--- a/core/src/main/kotlin/me/lazmaid/kraph/lang/DataEntry.kt
+++ b/core/src/main/kotlin/me/lazmaid/kraph/lang/DataEntry.kt
@@ -1,0 +1,59 @@
+package me.lazmaid.kraph.lang
+
+import javax.xml.crypto.Data
+
+/**
+ * Created by vwongsawangt on 8/6/2017 AD.
+ */
+
+internal sealed class DataEntry {
+    abstract fun print(prettyFormat: Boolean): String
+
+    class NonDecimalNumberData(val value: Long) : DataEntry() {
+        override fun print(prettyFormat: Boolean) = value.toString()
+    }
+
+    class DecimalNumberData(val value: Double) : DataEntry() {
+        override fun print(prettyFormat: Boolean) = value.toString()
+    }
+
+    class BooleanData(val value: Boolean) : DataEntry() {
+        override fun print(prettyFormat: Boolean) = value.toString()
+    }
+
+    class StringData(val value: String) : DataEntry() {
+        override fun print(prettyFormat: Boolean) =
+                if (prettyFormat) {
+                    "\"$value\""
+                } else {
+                    "\\\"$value\\\""
+                }
+    }
+
+    class ArrayData(val values: List<DataEntry>) : DataEntry() {
+        override fun print(prettyFormat: Boolean) =
+                values.foldIndexed("[") { index, acc, item ->
+                    var newAcc = acc + item.print(prettyFormat)
+                    if (index != values.size - 1) {
+                        newAcc += ", "
+                    } else {
+                        newAcc += "]"
+                    }
+                    newAcc
+                }
+    }
+
+    class ObjectData(val values: List<Pair<String, DataEntry>>) : DataEntry() {
+        override fun print(prettyFormat: Boolean) =
+                values.foldIndexed("{") { index, acc, (k, v) ->
+                    var newAcc = acc + "${k.wrappedWithQuotes(prettyFormat)}: ${v.print(prettyFormat)}"
+                    if (index != values.size - 1) {
+                        newAcc += ", "
+                    } else {
+                        newAcc += "}"
+                    }
+                    newAcc
+                }
+    }
+}
+

--- a/core/src/main/kotlin/me/lazmaid/kraph/lang/DataEntry.kt
+++ b/core/src/main/kotlin/me/lazmaid/kraph/lang/DataEntry.kt
@@ -5,25 +5,25 @@ package me.lazmaid.kraph.lang
  */
 
 internal sealed class DataEntry {
-    abstract fun print(prettyFormat: Boolean, escapeStrings: Boolean): String
+    abstract fun print(format: PrintFormat): String
 
     class NonDecimalNumberData(private val value: Long) : DataEntry() {
         constructor(value: Int) : this(value.toLong())
 
-        override fun print(prettyFormat: Boolean, escapeStrings: Boolean) = value.toString()
+        override fun print(format: PrintFormat) = value.toString()
     }
 
     class DecimalNumberData(private val value: Double) : DataEntry() {
-        override fun print(prettyFormat: Boolean, escapeStrings: Boolean) = value.toString()
+        override fun print(format: PrintFormat) = value.toString()
     }
 
     class BooleanData(private val value: Boolean) : DataEntry() {
-        override fun print(prettyFormat: Boolean, escapeStrings: Boolean) = value.toString()
+        override fun print(format: PrintFormat) = value.toString()
     }
 
     class StringData(private val value: String) : DataEntry() {
-        override fun print(prettyFormat: Boolean, escapeStrings: Boolean) =
-                if (escapeStrings) {
+        override fun print(format: PrintFormat) =
+                if (format == PrintFormat.JSON) {
                     "\\\"$value\\\""
                 } else {
                     "\"$value\""
@@ -31,14 +31,14 @@ internal sealed class DataEntry {
     }
 
     class ArrayData(private val values: List<DataEntry>) : DataEntry() {
-        override fun print(prettyFormat: Boolean, escapeStrings: Boolean) =
-            "[${ values.joinToString(", ") { it.print(prettyFormat, escapeStrings) } }]"
+        override fun print(format: PrintFormat) =
+            "[${ values.joinToString(", ") { it.print(format) } }]"
     }
 
     class ObjectData(private val values: List<Pair<String, DataEntry>>) : DataEntry() {
-        override fun print(prettyFormat: Boolean, escapeStrings: Boolean) =
+        override fun print(format: PrintFormat) =
             "{${ values.joinToString(", ") { (k, v) ->
-                "${k}: ${v.print(prettyFormat, escapeStrings)}"
+                "${k}: ${v.print(format)}"
             } }}"
     }
 }

--- a/core/src/main/kotlin/me/lazmaid/kraph/lang/DataEntry.kt
+++ b/core/src/main/kotlin/me/lazmaid/kraph/lang/DataEntry.kt
@@ -7,53 +7,38 @@ import javax.xml.crypto.Data
  */
 
 internal sealed class DataEntry {
-    abstract fun print(prettyFormat: Boolean): String
+    abstract fun print(prettyFormat: Boolean, escapeStrings: Boolean): String
 
     class NonDecimalNumberData(val value: Long) : DataEntry() {
-        override fun print(prettyFormat: Boolean) = value.toString()
+        override fun print(prettyFormat: Boolean, escapeStrings: Boolean) = value.toString()
     }
 
     class DecimalNumberData(val value: Double) : DataEntry() {
-        override fun print(prettyFormat: Boolean) = value.toString()
+        override fun print(prettyFormat: Boolean, escapeStrings: Boolean) = value.toString()
     }
 
     class BooleanData(val value: Boolean) : DataEntry() {
-        override fun print(prettyFormat: Boolean) = value.toString()
+        override fun print(prettyFormat: Boolean, escapeStrings: Boolean) = value.toString()
     }
 
     class StringData(val value: String) : DataEntry() {
-        override fun print(prettyFormat: Boolean) =
-                if (prettyFormat) {
-                    "\"$value\""
-                } else {
+        override fun print(prettyFormat: Boolean, escapeStrings: Boolean) =
+                if (escapeStrings) {
                     "\\\"$value\\\""
+                } else {
+                    "\"$value\""
                 }
     }
 
     class ArrayData(val values: List<DataEntry>) : DataEntry() {
-        override fun print(prettyFormat: Boolean) =
-                values.foldIndexed("[") { index, acc, item ->
-                    var newAcc = acc + item.print(prettyFormat)
-                    if (index != values.size - 1) {
-                        newAcc += ", "
-                    } else {
-                        newAcc += "]"
-                    }
-                    newAcc
-                }
+        override fun print(prettyFormat: Boolean, escapeStrings: Boolean) =
+            "[${ values.joinToString(", ") { it.print(prettyFormat, escapeStrings) } }]"
     }
 
     class ObjectData(val values: List<Pair<String, DataEntry>>) : DataEntry() {
-        override fun print(prettyFormat: Boolean) =
-                values.foldIndexed("{") { index, acc, (k, v) ->
-                    var newAcc = acc + "${k.wrappedWithQuotes(prettyFormat)}: ${v.print(prettyFormat)}"
-                    if (index != values.size - 1) {
-                        newAcc += ", "
-                    } else {
-                        newAcc += "}"
-                    }
-                    newAcc
-                }
+        override fun print(prettyFormat: Boolean, escapeStrings: Boolean) =
+            "{${ values.joinToString(", ") { (k, v) ->
+                "${k}: ${v.print(prettyFormat, escapeStrings)}"
+            } }}"
     }
 }
-

--- a/core/src/main/kotlin/me/lazmaid/kraph/lang/Document.kt
+++ b/core/src/main/kotlin/me/lazmaid/kraph/lang/Document.kt
@@ -6,9 +6,13 @@ package me.lazmaid.kraph.lang
 
 internal class Document(internal val operation: Operation) : GraphQLNode() {
     internal val variables: Variables = Variables()
-    override fun print(prettyFormat: Boolean, previousLevel: Int): String {
-        val operationNamePart = operation.printName()
+    override fun print(
+        prettyFormat: Boolean,
+        escapeStrings: Boolean,
+        previousLevel: Int
+    ): String {
+        val operationNamePart = operation.name?.let{ "\"$it\"" }
         val variablesPart = variables.print()
-        return "{\"query\": \"${operation.print(prettyFormat, previousLevel)}\", \"variables\": $variablesPart, \"operationName\": $operationNamePart}"
+        return "{\"query\": \"${operation.print(prettyFormat, escapeStrings, previousLevel)}\", \"variables\": $variablesPart, \"operationName\": $operationNamePart}"
     }
 }

--- a/core/src/main/kotlin/me/lazmaid/kraph/lang/Document.kt
+++ b/core/src/main/kotlin/me/lazmaid/kraph/lang/Document.kt
@@ -7,12 +7,11 @@ package me.lazmaid.kraph.lang
 internal class Document(internal val operation: Operation) : GraphQLNode() {
     internal val variables: Variables = Variables()
     override fun print(
-        prettyFormat: Boolean,
-        escapeStrings: Boolean,
+        format: PrintFormat,
         previousLevel: Int
     ): String {
         val operationNamePart = operation.name?.let{ "\"$it\"" }
         val variablesPart = variables.print()
-        return "{\"query\": \"${operation.print(prettyFormat, escapeStrings, previousLevel)}\", \"variables\": $variablesPart, \"operationName\": $operationNamePart}"
+        return "{\"query\": \"${operation.print(PrintFormat.JSON, previousLevel)}\", \"variables\": $variablesPart, \"operationName\": $operationNamePart}"
     }
 }

--- a/core/src/main/kotlin/me/lazmaid/kraph/lang/Document.kt
+++ b/core/src/main/kotlin/me/lazmaid/kraph/lang/Document.kt
@@ -5,11 +5,10 @@ package me.lazmaid.kraph.lang
  */
 
 internal class Document(internal val operation: Operation) : GraphQLNode() {
+    internal val variables: Variables = Variables()
     override fun print(prettyFormat: Boolean, previousLevel: Int): String {
-        val operationNamePart = operation.name?.let {
-            "\"$it\""
-        }
-        val variablesPart = null
+        val operationNamePart = operation.printName()
+        val variablesPart = variables.print()
         return "{\"query\": \"${operation.print(prettyFormat, previousLevel)}\", \"variables\": $variablesPart, \"operationName\": $operationNamePart}"
     }
 }

--- a/core/src/main/kotlin/me/lazmaid/kraph/lang/Field.kt
+++ b/core/src/main/kotlin/me/lazmaid/kraph/lang/Field.kt
@@ -4,13 +4,18 @@ package me.lazmaid.kraph.lang
  * Created by VerachadW on 9/19/2016 AD.
  */
 
-internal open class Field(internal val name: String, internal val arguments: Argument? = null, internal var selectionSet: SelectionSet? = null) : GraphQLNode() {
-    override fun print(prettyFormat: Boolean, previousLevel: Int): String {
-        val selectionSetPart = selectionSet?.let { " " + it.print(prettyFormat, previousLevel) } ?: ""
-        return "$name${arguments?.print(prettyFormat, previousLevel) ?: ""}$selectionSetPart"
+internal open class Field(
+    internal val name: String,
+    internal val arguments: Argument? = null,
+    internal var selectionSet: SelectionSet? = null
+) : GraphQLNode() {
+    override fun print(
+        prettyFormat: Boolean,
+        escapeStrings: Boolean,
+        previousLevel: Int
+    ): String {
+        val selectionSetPart = selectionSet?.print(prettyFormat, escapeStrings, previousLevel)?.let{ " $it" } ?: ""
+        val argumentsPart = arguments?.print(prettyFormat, escapeStrings, previousLevel)?.let{ " $it" } ?: ""
+        return "$name$argumentsPart$selectionSetPart"
     }
 }
-
-
-
-

--- a/core/src/main/kotlin/me/lazmaid/kraph/lang/Field.kt
+++ b/core/src/main/kotlin/me/lazmaid/kraph/lang/Field.kt
@@ -10,12 +10,11 @@ internal open class Field(
     internal var selectionSet: SelectionSet? = null
 ) : GraphQLNode() {
     override fun print(
-        prettyFormat: Boolean,
-        escapeStrings: Boolean,
+        format: PrintFormat,
         previousLevel: Int
     ): String {
-        val selectionSetPart = selectionSet?.print(prettyFormat, escapeStrings, previousLevel)?.let{ " $it" } ?: ""
-        val argumentsPart = arguments?.print(prettyFormat, escapeStrings, previousLevel)?.let{ " $it" } ?: ""
+        val selectionSetPart = selectionSet?.print(format, previousLevel)?.let{ " $it" } ?: ""
+        val argumentsPart = arguments?.print(format, previousLevel)?.let{ " $it" } ?: ""
         return "$name$argumentsPart$selectionSetPart"
     }
 }

--- a/core/src/main/kotlin/me/lazmaid/kraph/lang/GraphQLNode.kt
+++ b/core/src/main/kotlin/me/lazmaid/kraph/lang/GraphQLNode.kt
@@ -39,6 +39,9 @@ abstract internal class GraphQLNode {
                 is Float -> {
                     DataEntry.DecimalNumberData(value.toDouble())
                 }
+                is Boolean -> {
+                    DataEntry.BooleanData(value)
+                }
                 is Double -> {
                     DataEntry.DecimalNumberData(value)
                 }
@@ -61,49 +64,3 @@ internal fun String.wrappedWithQuotes(shouldEscaped: Boolean) =
             "\\\"$this\\\""
         }
 
-internal sealed class DataEntry {
-    abstract fun print(prettyFormat: Boolean): String
-
-    class NonDecimalNumberData(val value: Long) : DataEntry() {
-        override fun print(prettyFormat: Boolean) = value.toString()
-    }
-
-    class DecimalNumberData(val value: Double) : DataEntry() {
-        override fun print(prettyFormat: Boolean) = value.toString()
-    }
-
-    class StringData(val value: String) : DataEntry() {
-        override fun print(prettyFormat: Boolean) =
-                if (prettyFormat) {
-                    "\"$value\""
-                } else {
-                    "\\\"$value\\\""
-                }
-    }
-
-    class ArrayData(val values: List<DataEntry>) : DataEntry() {
-        override fun print(prettyFormat: Boolean) =
-                values.foldIndexed("[") { index, acc, item ->
-                    var newAcc = acc + item.print(prettyFormat)
-                    if (index != values.size - 1) {
-                        newAcc += ", "
-                    } else {
-                        newAcc += "]"
-                    }
-                    newAcc
-                }
-    }
-
-    class ObjectData(val values: List<Pair<String, DataEntry>>) : DataEntry() {
-        override fun print(prettyFormat: Boolean) =
-                values.foldIndexed("{") { index, acc, (k, v) ->
-                    var newAcc = acc + "${k.wrappedWithQuotes(prettyFormat)}: ${v.print(prettyFormat)}"
-                    if (index != values.size - 1) {
-                        newAcc += ", "
-                    } else {
-                        newAcc += "}"
-                    }
-                    newAcc
-                }
-    }
-}

--- a/core/src/main/kotlin/me/lazmaid/kraph/lang/GraphQLNode.kt
+++ b/core/src/main/kotlin/me/lazmaid/kraph/lang/GraphQLNode.kt
@@ -3,14 +3,14 @@ package me.lazmaid.kraph.lang
 abstract internal class GraphQLNode {
     var level = 0
 
-    abstract fun print(prettyFormat: Boolean, escapeStrings: Boolean, previousLevel: Int): String
+    abstract fun print(format: PrintFormat, previousLevel: Int): String
 
     fun getIndentString(level: Int) = "  ".repeat(level)
-    fun getNewLineString(prettyFormat: Boolean) = if (prettyFormat) "\n" else " "
+    fun getNewLineString(format: PrintFormat) = if (format == PrintFormat.PRETTY) "\n" else " "
 
-    fun print(value: Map<String, Any?>, prettyFormat: Boolean, escapeStrings: Boolean) =
+    fun print(value: Map<String, Any?>, format: PrintFormat) =
         value.entries.joinToString(", ") { (k, v) ->
-            "$k: ${convertToDataEntry(v).print(prettyFormat, escapeStrings)}"
+            "$k: ${convertToDataEntry(v).print(format)}"
         }
 
     private fun convertToArrayData(value: List<*>): DataEntry.ArrayData =
@@ -42,3 +42,9 @@ internal fun String.wrappedWithQuotes(shouldBeEscaped: Boolean) =
         } else {
             "\\\"$this\\\""
         }
+
+internal enum class PrintFormat {
+    NORMAL,
+    PRETTY,
+    JSON
+}

--- a/core/src/main/kotlin/me/lazmaid/kraph/lang/GraphQLNode.kt
+++ b/core/src/main/kotlin/me/lazmaid/kraph/lang/GraphQLNode.kt
@@ -6,7 +6,7 @@ abstract internal class GraphQLNode {
     abstract fun print(prettyFormat: Boolean, previousLevel: Int): String
 
     fun getIndentString(level: Int) = "  ".repeat(level)
-    fun getNewLineString(prettyFormat: Boolean) = if (prettyFormat) "\n" else "\\n"
+    fun getNewLineString(prettyFormat: Boolean) = if (prettyFormat) "\n" else " "
 
     fun print(value: Map<String, Any?>, prettyFormat: Boolean) =
         value.entries.foldIndexed("") { index, acc, (k, v)->
@@ -63,4 +63,3 @@ internal fun String.wrappedWithQuotes(shouldEscaped: Boolean) =
         } else {
             "\\\"$this\\\""
         }
-

--- a/core/src/main/kotlin/me/lazmaid/kraph/lang/GraphQLNode.kt
+++ b/core/src/main/kotlin/me/lazmaid/kraph/lang/GraphQLNode.kt
@@ -3,21 +3,18 @@ package me.lazmaid.kraph.lang
 abstract internal class GraphQLNode {
     var level = 0
 
-    abstract fun print(prettyFormat: Boolean, previousLevel: Int): String
+    abstract fun print(prettyFormat: Boolean, escapeStrings: Boolean, previousLevel: Int): String
 
     fun getIndentString(level: Int) = "  ".repeat(level)
     fun getNewLineString(prettyFormat: Boolean) = if (prettyFormat) "\n" else " "
 
-    fun print(value: Map<String, Any?>, prettyFormat: Boolean) =
-        value.entries.foldIndexed("") { index, acc, (k, v)->
-            var newAcc = acc + "$k: ${convertToDataEntry(v).print(prettyFormat)}"
-            if (index != value.entries.size - 1) {
-                newAcc += ", "
-            }
-            newAcc
+    fun print(value: Map<String, Any?>, prettyFormat: Boolean, escapeStrings: Boolean) =
+        value.entries.joinToString(", ") { (k, v) ->
+            "$k: ${convertToDataEntry(v).print(prettyFormat, escapeStrings)}"
         }
 
-    private fun convertToArrayData(value: List<*>): DataEntry.ArrayData = DataEntry.ArrayData(value.map(this::convertToDataEntry))
+    private fun convertToArrayData(value: List<*>): DataEntry.ArrayData =
+        DataEntry.ArrayData(value.map(this::convertToDataEntry))
 
     private fun convertToObjectData(map: Map<String, *>): DataEntry.ObjectData =
         DataEntry.ObjectData(map.map {
@@ -27,38 +24,20 @@ abstract internal class GraphQLNode {
     @Suppress("UNCHECKED_CAST")
     private fun convertToDataEntry(value: Any?) =
             when(value) {
-                is String -> {
-                    DataEntry.StringData(value)
-                }
-                is Int -> {
-                    DataEntry.NonDecimalNumberData(value.toLong())
-                }
-                is Long -> {
-                    DataEntry.NonDecimalNumberData(value)
-                }
-                is Float -> {
-                    DataEntry.DecimalNumberData(value.toDouble())
-                }
-                is Boolean -> {
-                    DataEntry.BooleanData(value)
-                }
-                is Double -> {
-                    DataEntry.DecimalNumberData(value)
-                }
-                is List<*> -> {
-                    convertToArrayData(value)
-                }
-                is Map<*, *> -> {
-                    convertToObjectData(value as Map<String, *>)
-                }
-                else -> {
-                    throw RuntimeException("Unsupported Type")
-                }
+                is String   -> DataEntry.StringData(value)
+                is Int      -> DataEntry.NonDecimalNumberData(value.toLong())
+                is Long     -> DataEntry.NonDecimalNumberData(value)
+                is Float    -> DataEntry.DecimalNumberData(value.toDouble())
+                is Boolean  -> DataEntry.BooleanData(value)
+                is Double   -> DataEntry.DecimalNumberData(value)
+                is List<*>  -> convertToArrayData(value)
+                is Map<*,*> -> convertToObjectData(value as Map<String, *>)
+                else        -> throw RuntimeException("Unsupported Type")
             }
 }
 
-internal fun String.wrappedWithQuotes(shouldEscaped: Boolean) =
-        if (shouldEscaped) {
+internal fun String.wrappedWithQuotes(shouldBeEscaped: Boolean) =
+        if (shouldBeEscaped) {
             "\"$this\""
         } else {
             "\\\"$this\\\""

--- a/core/src/main/kotlin/me/lazmaid/kraph/lang/Operation.kt
+++ b/core/src/main/kotlin/me/lazmaid/kraph/lang/Operation.kt
@@ -11,13 +11,12 @@ internal class Operation(
     internal val arguments: Argument? = null
 ) : GraphQLNode() {
     override fun print(
-        prettyFormat: Boolean,
-        escapeStrings: Boolean,
+        format: PrintFormat,
         previousLevel: Int
     ): String {
         val namePart = name?.let{ " $it" } ?: ""
-        val argumentPart = arguments?.print(prettyFormat, escapeStrings, previousLevel)?.let{ " $it" } ?: ""
-        return "${type.name.toLowerCase()}$namePart$argumentPart ${selectionSet.print(prettyFormat, escapeStrings, previousLevel)}"
+        val argumentPart = arguments?.print(format, previousLevel)?.let{ " $it" } ?: ""
+        return "${type.name.toLowerCase()}$namePart$argumentPart ${selectionSet.print(format, previousLevel)}"
     }
 }
 

--- a/core/src/main/kotlin/me/lazmaid/kraph/lang/Operation.kt
+++ b/core/src/main/kotlin/me/lazmaid/kraph/lang/Operation.kt
@@ -4,16 +4,21 @@ package me.lazmaid.kraph.lang
  * Created by VerachadW on 10/2/2016 AD.
  */
 
-internal class Operation(internal val type: OperationType, internal val selectionSet: SelectionSet,
-                         internal val name: String? = null, internal val arguments: Argument? = null) : GraphQLNode() {
-
-    override fun print(prettyFormat: Boolean, previousLevel: Int): String {
-        val namePart = name?.let { " " + it } ?: ""
-        val argumentPart = arguments?.print(prettyFormat, previousLevel) ?: ""
-        return "${type.name.toLowerCase()}$namePart$argumentPart ${selectionSet.print(prettyFormat, previousLevel)}"
+internal class Operation(
+    internal val type: OperationType,
+    internal val selectionSet: SelectionSet,
+    internal val name: String? = null,
+    internal val arguments: Argument? = null
+) : GraphQLNode() {
+    override fun print(
+        prettyFormat: Boolean,
+        escapeStrings: Boolean,
+        previousLevel: Int
+    ): String {
+        val namePart = name?.let{ " $it" } ?: ""
+        val argumentPart = arguments?.print(prettyFormat, escapeStrings, previousLevel)?.let{ " $it" } ?: ""
+        return "${type.name.toLowerCase()}$namePart$argumentPart ${selectionSet.print(prettyFormat, escapeStrings, previousLevel)}"
     }
-
-    fun printName(): String? = name?.let { "\"$it\"" }
 }
 
 internal enum class OperationType {

--- a/core/src/main/kotlin/me/lazmaid/kraph/lang/Operation.kt
+++ b/core/src/main/kotlin/me/lazmaid/kraph/lang/Operation.kt
@@ -12,6 +12,8 @@ internal class Operation(internal val type: OperationType, internal val selectio
         val argumentPart = arguments?.print(prettyFormat, previousLevel) ?: ""
         return "${type.name.toLowerCase()}$namePart$argumentPart ${selectionSet.print(prettyFormat, previousLevel)}"
     }
+
+    fun printName(): String? = name?.let { "\"$it\"" }
 }
 
 internal enum class OperationType {

--- a/core/src/main/kotlin/me/lazmaid/kraph/lang/SelectionSet.kt
+++ b/core/src/main/kotlin/me/lazmaid/kraph/lang/SelectionSet.kt
@@ -7,13 +7,12 @@ package me.lazmaid.kraph.lang
 internal class SelectionSet(internal val fields: List<Field>) : GraphQLNode() {
 
     override fun print(
-        prettyFormat: Boolean,
-        escapeStrings: Boolean,
+        format: PrintFormat,
         previousLevel: Int
     ): String {
-        val nl = getNewLineString(prettyFormat)
-        if (prettyFormat) level = previousLevel + 1 else level = 0
-        val fieldStr = fields.joinToString(nl) { getIndentString(level) + it.print(prettyFormat, escapeStrings, level) }
+        val nl = getNewLineString(format)
+        if (format == PrintFormat.PRETTY) level = previousLevel + 1 else level = 0
+        val fieldStr = fields.joinToString(nl) { getIndentString(level) + it.print(format, level) }
         return "{${ nl + fieldStr + nl + getIndentString(previousLevel) }}"
     }
 }

--- a/core/src/main/kotlin/me/lazmaid/kraph/lang/SelectionSet.kt
+++ b/core/src/main/kotlin/me/lazmaid/kraph/lang/SelectionSet.kt
@@ -6,12 +6,14 @@ package me.lazmaid.kraph.lang
 
 internal class SelectionSet(internal val fields: List<Field>) : GraphQLNode() {
 
-    override fun print(prettyFormat: Boolean, previousLevel: Int): String {
+    override fun print(
+        prettyFormat: Boolean,
+        escapeStrings: Boolean,
+        previousLevel: Int
+    ): String {
+        val nl = getNewLineString(prettyFormat)
         if (prettyFormat) level = previousLevel + 1 else level = 0
-        return "{${
-             getNewLineString(prettyFormat) + fields.fold("") { acc, node ->
-                 acc + getIndentString(level) + node.print(prettyFormat, level) + getNewLineString(prettyFormat)
-            } + getIndentString(previousLevel)
-        }}"
+        val fieldStr = fields.joinToString(nl) { getIndentString(level) + it.print(prettyFormat, escapeStrings, level) }
+        return "{${ nl + fieldStr + nl + getIndentString(previousLevel) }}"
     }
 }

--- a/core/src/main/kotlin/me/lazmaid/kraph/lang/Variables.kt
+++ b/core/src/main/kotlin/me/lazmaid/kraph/lang/Variables.kt
@@ -1,0 +1,10 @@
+package me.lazmaid.kraph.lang
+
+/**
+ * Created by OinkIguana on 10/25/2017 AD.
+ */
+
+// TODO: implement variables
+internal class Variables() {
+    fun print(): String? = null
+}

--- a/core/src/main/kotlin/me/lazmaid/kraph/lang/relay/CursorConnection.kt
+++ b/core/src/main/kotlin/me/lazmaid/kraph/lang/relay/CursorConnection.kt
@@ -9,9 +9,15 @@ import me.lazmaid.kraph.lang.SelectionSet
  * Created by VerachadW on 10/2/2016 AD.
  */
 
-internal class CursorConnection(name: String, argument: Argument, selectionSet: SelectionSet) : Field(name, arguments = argument, selectionSet = selectionSet)
+internal class CursorConnection(
+    name: String,
+    argument: Argument,
+    selectionSet: SelectionSet
+) : Field(name, arguments = argument, selectionSet = selectionSet)
 
-internal class Edges(nodeSelectionSet: SelectionSet, additionalField: List<Field> = listOf()) : Field("edges", selectionSet = SelectionSet(listOf(Field("node", selectionSet = nodeSelectionSet)) + additionalField))
+internal class Edges(
+    nodeSelectionSet: SelectionSet,
+    additionalField: List<Field> = listOf()
+) : Field("edges", selectionSet = SelectionSet(listOf(Field("node", selectionSet = nodeSelectionSet)) + additionalField))
 
 internal class PageInfo (pageSelectionSet: SelectionSet) : Field("pageInfo", selectionSet = pageSelectionSet)
-

--- a/core/src/main/kotlin/me/lazmaid/kraph/lang/relay/InputArgument.kt
+++ b/core/src/main/kotlin/me/lazmaid/kraph/lang/relay/InputArgument.kt
@@ -1,6 +1,7 @@
 package me.lazmaid.kraph.lang.relay
 
 import me.lazmaid.kraph.lang.Argument
+import me.lazmaid.kraph.lang.PrintFormat
 
 /**
  * Created by VerachadW on 10/2/2016 AD.
@@ -8,10 +9,9 @@ import me.lazmaid.kraph.lang.Argument
 
 internal class InputArgument(args: Map<String, Any>) : Argument(args) {
     override fun print(
-        prettyFormat: Boolean,
-        escapeStrings: Boolean,
+        format: PrintFormat,
         previousLevel: Int
     ): String {
-        return "(input: { ${print(args, prettyFormat, escapeStrings)} })"
+        return "(input: { ${print(args, format) } })"
     }
 }

--- a/core/src/main/kotlin/me/lazmaid/kraph/lang/relay/InputArgument.kt
+++ b/core/src/main/kotlin/me/lazmaid/kraph/lang/relay/InputArgument.kt
@@ -7,7 +7,11 @@ import me.lazmaid.kraph.lang.Argument
  */
 
 internal class InputArgument(args: Map<String, Any>) : Argument(args) {
-    override fun print(prettyFormat: Boolean, previousLevel: Int): String {
-        return "(input: { ${print(args, prettyFormat)} })"
+    override fun print(
+        prettyFormat: Boolean,
+        escapeStrings: Boolean,
+        previousLevel: Int
+    ): String {
+        return "(input: { ${print(args, prettyFormat, escapeStrings)} })"
     }
 }

--- a/core/src/test/kotlin/me/lazmaid/kraph/test/BuilderSpek.kt
+++ b/core/src/test/kotlin/me/lazmaid/kraph/test/BuilderSpek.kt
@@ -66,7 +66,7 @@ class BuilderSpek : Spek({
                 assertThat(query.document.operation.selectionSet.fields[0].selectionSet!!.fields[2].selectionSet!!.fields[1].name, equalTo("email"))
             }
             it("should be able to print the request for network call") {
-                assertThat(query.toRequestString(), equalTo("{\"query\": \"query getAllNotes {\\nnotes {\\nid\\ncontent\\nauthor {\\nname\\nemail\\n}\\navatarUrl(size: 100)\\n}\\n}\", \"variables\": null, \"operationName\": \"getAllNotes\"}"))
+                assertThat(query.toRequestString(), equalTo("{\"query\": \"query getAllNotes { notes { id content author { name email } avatarUrl(size: 100) } }\", \"variables\": null, \"operationName\": \"getAllNotes\"}"))
             }
             it("should be able to print GraphQL query content with pretty format") {
                 assertThat(query.toGraphQueryString(), equalTo("query getAllNotes {\n  notes {\n    id\n    content\n    author {\n      name\n      email\n    }\n    avatarUrl(size: 100)\n  }\n}"))

--- a/core/src/test/kotlin/me/lazmaid/kraph/test/BuilderSpek.kt
+++ b/core/src/test/kotlin/me/lazmaid/kraph/test/BuilderSpek.kt
@@ -76,8 +76,7 @@ class BuilderSpek : Spek({
             it("should throw NoFieldsInSelectionSetException") {
                 assertThat({
                     Kraph {
-                        query {
-                        }
+                        query { }
                     }
                 }, throws(noFieldInSelectionSetMessageMatcher("query")))
             }

--- a/core/src/test/kotlin/me/lazmaid/kraph/test/BuilderSpek.kt
+++ b/core/src/test/kotlin/me/lazmaid/kraph/test/BuilderSpek.kt
@@ -66,10 +66,10 @@ class BuilderSpek : Spek({
                 assertThat(query.document.operation.selectionSet.fields[0].selectionSet!!.fields[2].selectionSet!!.fields[1].name, equalTo("email"))
             }
             it("should be able to print the request for network call") {
-                assertThat(query.toRequestString(), equalTo("{\"query\": \"query getAllNotes { notes { id content author { name email } avatarUrl(size: 100) } }\", \"variables\": null, \"operationName\": \"getAllNotes\"}"))
+                assertThat(query.toRequestString(), equalTo("{\"query\": \"query getAllNotes { notes { id content author { name email } avatarUrl (size: 100) } }\", \"variables\": null, \"operationName\": \"getAllNotes\"}"))
             }
             it("should be able to print GraphQL query content with pretty format") {
-                assertThat(query.toGraphQueryString(), equalTo("query getAllNotes {\n  notes {\n    id\n    content\n    author {\n      name\n      email\n    }\n    avatarUrl(size: 100)\n  }\n}"))
+                assertThat(query.toGraphQueryString(), equalTo("query getAllNotes {\n  notes {\n    id\n    content\n    author {\n      name\n      email\n    }\n    avatarUrl (size: 100)\n  }\n}"))
             }
         }
         given("sample query with no field in selection set") {

--- a/core/src/test/kotlin/me/lazmaid/kraph/test/BuilderSpek.kt
+++ b/core/src/test/kotlin/me/lazmaid/kraph/test/BuilderSpek.kt
@@ -4,6 +4,7 @@ import com.natpryce.hamkrest.*
 import com.natpryce.hamkrest.assertion.assertThat
 import me.lazmaid.kraph.Kraph
 import me.lazmaid.kraph.NoFieldsInSelectionSetException
+import me.lazmaid.kraph.NoSuchFragmentException
 import me.lazmaid.kraph.lang.OperationType
 import me.lazmaid.kraph.lang.relay.CursorConnection
 import me.lazmaid.kraph.lang.relay.PageInfo
@@ -256,7 +257,7 @@ class BuilderSpek : Spek({
                     field("name")
                     field("email")
                 }
-                Kraph {
+                val query = Kraph {
                     query {
                         field("user") {
                             fragment("UserFragment")
@@ -279,7 +280,7 @@ class BuilderSpek : Spek({
 
 val cursorEmptyArgumentsMessageMatcher = Matcher(Exception::checkExceptionMessage, "There must be at least 1 argument for Cursor Connection")
 val pageInfoNoValidFieldMessageMatcher = Matcher(Exception::checkExceptionMessage, "Selection Set must contain hasNextPage and/or hasPreviousPage field")
-val noSuchFragmentMessageMatcher = Matcher(Exception::checkExceptionMessage, "No fragment named FakeFragment has been defined.")
+val noSuchFragmentMessageMatcher = Matcher(Exception::checkExceptionMessage, "No fragment named \"FakeFragment\" has been defined.")
 fun noFieldInSelectionSetMessageMatcher(name: String) = Matcher(Exception::checkExceptionMessage, "No field elements inside \"$name\" block")
 
 fun Exception.checkExceptionMessage(message: String) = this.message == message

--- a/core/src/test/kotlin/me/lazmaid/kraph/test/DataEntrySpek.kt
+++ b/core/src/test/kotlin/me/lazmaid/kraph/test/DataEntrySpek.kt
@@ -2,125 +2,43 @@ package me.lazmaid.kraph.test
 
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
-import com.natpryce.hamkrest.isA
 import me.lazmaid.kraph.lang.DataEntry
+import me.lazmaid.kraph.lang.PrintFormat
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.given
 import org.jetbrains.spek.api.dsl.it
 
 class DataEntrySpek : Spek({
-    describe("NonDecimalNumberDataEntry class") {
-        given("value as 5 and print pretty is false") {
-            val entry = DataEntry.NonDecimalNumberData(5)
-            val valueString = entry.print(false, false)
-            it("should print \"5\"") {
-                assertThat(valueString, isA(equalTo("5")))
+    data class Expectation(val normal: String, val pretty: String, val json: String)
+    val tests = listOf(
+        Pair(DataEntry.NonDecimalNumberData(5), Expectation("5", "5", "5")),
+        Pair(DataEntry.DecimalNumberData(5.0), Expectation("5.0", "5.0", "5.0")),
+        Pair(DataEntry.BooleanData(true), Expectation("true", "true", "true")),
+        Pair(DataEntry.StringData("Hello world"), Expectation("\"Hello world\"", "\"Hello world\"", "\\\"Hello world\\\"")),
+        Pair(DataEntry.ArrayData(listOf(1, 2, 3).map { DataEntry.NonDecimalNumberData(it) }), Expectation("[1, 2, 3]", "[1, 2, 3]", "[1, 2, 3]")),
+        Pair(DataEntry.ObjectData(
+            listOf(
+                "name" to DataEntry.StringData("John Doe"),
+                "age" to DataEntry.NonDecimalNumberData(18))
+            ),
+            Expectation(
+                "{name: \"John Doe\", age: 18}",
+                "{name: \"John Doe\", age: 18}",
+                "{name: \\\"John Doe\\\", age: 18}"
+            )
+        )
+    )
+    for((node, expectation) in tests) {
+        describe("${node::class.simpleName}") {
+            it("should print correctly in NORMAL mode") {
+                assertThat(node.print(PrintFormat.NORMAL), equalTo(expectation.normal))
             }
-        }
-        given("value as 5 and print pretty is true") {
-            val entry = DataEntry.NonDecimalNumberData(5)
-            val valueString = entry.print(true, false)
-            it("should print \"5\"") {
-                assertThat(valueString, isA(equalTo("5")))
+            it("should print correctly in PRETTY mode") {
+                assertThat(node.print(PrintFormat.PRETTY), equalTo(expectation.pretty))
             }
-        }
-    }
-
-    describe("DecimalNumberDataEntry class") {
-        given("value as 5.0 and print pretty is false") {
-            val entry = DataEntry.DecimalNumberData(5.0)
-            val valueString = entry.print(false, false)
-            it("should print \"5.0\"") {
-                assertThat(valueString, isA(equalTo("5.0")))
-            }
-        }
-        given("value as 5.0 and print pretty is true") {
-            val entry = DataEntry.DecimalNumberData(5.0)
-            val valueString = entry.print(true, false)
-            it("should print \"5.0\"") {
-                assertThat(valueString, isA(equalTo("5.0")))
-            }
-        }
-    }
-
-    describe("BooleanDataEntry class") {
-        given("value as true and print pretty is false") {
-            val entry = DataEntry.BooleanData(true)
-            val valueString = entry.print(false, false)
-            it("should print \"true\"") {
-                assertThat(valueString, isA(equalTo("true")))
-            }
-        }
-        given("value as true and print pretty is true") {
-            val entry = DataEntry.BooleanData(true)
-            val valueString = entry.print(true, false)
-            it("should print \"true\"") {
-                assertThat(valueString, isA(equalTo("true")))
-            }
-        }
-    }
-
-    describe("StringDataEntry class") {
-        given("value as 'Hello World' and print pretty is false and escapeStrings as false") {
-            val entry = DataEntry.StringData("Hello World")
-            val valueString = entry.print(false, false)
-            it("should print \"Hello World\"") {
-                assertThat(valueString, isA(equalTo("\"Hello World\"")))
-            }
-        }
-        given("value as 'Hello World' and print pretty is false and escapeStrings as true") {
-            val entry = DataEntry.StringData("Hello World")
-            val valueString = entry.print(false, true)
-            it("should print \\\"Hello World\\\"") {
-                assertThat(valueString, isA(equalTo("\\\"Hello World\\\"")))
-            }
-        }
-        given("value as true and print pretty is true and escapeStrings is false") {
-            val entry = DataEntry.StringData("Hello World")
-            val valueString = entry.print(true, false)
-            it("should print \"Hello World\"") {
-                assertThat(valueString, isA(equalTo("\"Hello World\"")))
-            }
-        }
-    }
-
-    describe("ArrayDataEntry class") {
-        given("value as [1,2,3] and print pretty is false") {
-            val values = listOf(1, 2, 3).map { DataEntry.NonDecimalNumberData(it) }
-            val entry = DataEntry.ArrayData(values)
-            val valueString = entry.print(false, false)
-            it("should print [1, 2, 3]") {
-                assertThat(valueString, isA(equalTo("[1, 2, 3]")))
-            }
-        }
-        given("vale as [1,2,3] and print pretty is true") {
-            val values = listOf(1, 2, 3).map { DataEntry.NonDecimalNumberData(it) }
-            val entry = DataEntry.ArrayData(values)
-            val valueString = entry.print(true, false)
-            it("should print [1, 2, 3]") {
-                assertThat(valueString, isA(equalTo("[1, 2, 3]")))
-            }
-        }
-    }
-
-    describe("ObjectDataEntry class") {
-        given("with key-values and print pretty as false") {
-            val values = listOf("name" to DataEntry.StringData("John Doe"),
-                    "age" to DataEntry.NonDecimalNumberData(18))
-            val entry = DataEntry.ObjectData(values)
-            val valueString = entry.print(false, true)
-            it("should print {name: \\\"John Doe\\\", age: 18}") {
-                assertThat(valueString, isA(equalTo("{name: \\\"John Doe\\\", age: 18}")))
-            }
-        }
-        given("with key-values and print pretty as true") {
-            val values = listOf("name" to DataEntry.StringData("John Doe"),
-                    "age" to DataEntry.NonDecimalNumberData(18))
-            val entry = DataEntry.ObjectData(values)
-            val valueString = entry.print(true, false)
-            it("should print {name: \"John Doe\", age: 18}") {
-                assertThat(valueString, isA(equalTo("{name: \"John Doe\", age: 18}")))
+            it("should print correctly in JSON mode") {
+                assertThat(node.print(PrintFormat.JSON), equalTo(expectation.json))
             }
         }
     }

--- a/core/src/test/kotlin/me/lazmaid/kraph/test/GraphQLPrintSpek.kt
+++ b/core/src/test/kotlin/me/lazmaid/kraph/test/GraphQLPrintSpek.kt
@@ -40,6 +40,19 @@ class GraphQLPrintSpek : Spek({
                 }
             }
         }
+        given("isCancel as argument and value as false") {
+            val node = Argument(mapOf("isCancel" to false))
+            on("print pretty") {
+                it("should print (isCancel: false)") {
+                    assertThat(node.print(true, 0), equalTo("(isCancel: false)"))
+                }
+            }
+            on("print normal") {
+                it("should print (isCancel: false)") {
+                    assertThat(node.print(false, 0), equalTo("(isCancel: false)"))
+                }
+            }
+        }
         given("id and title as arguments and value as 1 and Kraph") {
             val node = Argument(mapOf("id" to 1, "title" to "Kraph"))
             on("print pretty") {

--- a/core/src/test/kotlin/me/lazmaid/kraph/test/GraphQLPrintSpek.kt
+++ b/core/src/test/kotlin/me/lazmaid/kraph/test/GraphQLPrintSpek.kt
@@ -18,12 +18,12 @@ class GraphQLPrintSpek : Spek({
             val node = Argument(mapOf("id" to 1))
             on("print pretty") {
                 it("should print (id: 1)") {
-                    assertThat(node.print(true, 0), equalTo("(id: 1)"))
+                    assertThat(node.print(true, false, 0), equalTo("(id: 1)"))
                 }
             }
             on("print normal") {
                 it("should print (id: 1)") {
-                    assertThat(node.print(false, 0), equalTo("(id: 1)"))
+                    assertThat(node.print(false, false, 0), equalTo("(id: 1)"))
                 }
             }
         }
@@ -31,12 +31,12 @@ class GraphQLPrintSpek : Spek({
             val node = Argument(mapOf("money" to 123.45))
             on("print pretty") {
                 it("should print (money: 123.45)") {
-                    assertThat(node.print(true, 0), equalTo("(money: 123.45)"))
+                    assertThat(node.print(true, false, 0), equalTo("(money: 123.45)"))
                 }
             }
             on("print normal") {
                 it("should print (money: 123.45)") {
-                    assertThat(node.print(false, 0), equalTo("(money: 123.45)"))
+                    assertThat(node.print(false, false, 0), equalTo("(money: 123.45)"))
                 }
             }
         }
@@ -44,12 +44,12 @@ class GraphQLPrintSpek : Spek({
             val node = Argument(mapOf("isCancel" to false))
             on("print pretty") {
                 it("should print (isCancel: false)") {
-                    assertThat(node.print(true, 0), equalTo("(isCancel: false)"))
+                    assertThat(node.print(true, false, 0), equalTo("(isCancel: false)"))
                 }
             }
             on("print normal") {
                 it("should print (isCancel: false)") {
-                    assertThat(node.print(false, 0), equalTo("(isCancel: false)"))
+                    assertThat(node.print(false, false, 0), equalTo("(isCancel: false)"))
                 }
             }
         }
@@ -57,12 +57,12 @@ class GraphQLPrintSpek : Spek({
             val node = Argument(mapOf("id" to 1, "title" to "Kraph"))
             on("print pretty") {
                 it("should print (id: 1, title: \"Kraph\")") {
-                    assertThat(node.print(true, 0), equalTo("(id: 1, title: \"Kraph\")"))
+                    assertThat(node.print(true, false, 0), equalTo("(id: 1, title: \"Kraph\")"))
                 }
             }
             on("print normal") {
                 it("should print (id: 1, title: \\\"Kraph\\\")") {
-                    assertThat(node.print(false, 0), equalTo("(id: 1, title: \\\"Kraph\\\")"))
+                    assertThat(node.print(false, true, 0), equalTo("(id: 1, title: \\\"Kraph\\\")"))
                 }
             }
         }
@@ -70,26 +70,26 @@ class GraphQLPrintSpek : Spek({
             val node = Argument(mapOf("titles" to listOf("title1", "title2")))
             on("print pretty") {
                 it("should print (titles: [\"title1\", \"title2\"]") {
-                    assertThat(node.print(true, 0), equalTo("(titles: [\"title1\", \"title2\"])"))
+                    assertThat(node.print(true, false, 0), equalTo("(titles: [\"title1\", \"title2\"])"))
                 }
             }
             on("print normal") {
                 it("should print (titles: [\\\"title1\\\", \\\"title2\\\"]") {
-                    assertThat(node.print(false, 0), equalTo("(titles: [\\\"title1\\\", \\\"title2\\\"])"))
+                    assertThat(node.print(false, true, 0), equalTo("(titles: [\\\"title1\\\", \\\"title2\\\"])"))
                 }
             }
         }
-        given("an user object as argument") {
+        given("a user object as argument") {
             val user = mapOf("name" to "John Doe", "email" to "john.doe@test.com")
             val node = Argument(mapOf("user" to user))
             on("print pretty") {
-                it("should print (user: {\"name\": \"John Doe\", \"email\": \"john.doe@test.com\"})") {
-                    assertThat(node.print(true, 0), equalTo("(user: {\"name\": \"John Doe\", \"email\": \"john.doe@test.com\"})"))
+                it("should print (user: {name: \"John Doe\", email: \"john.doe@test.com\"})") {
+                    assertThat(node.print(true, false, 0), equalTo("(user: {name: \"John Doe\", email: \"john.doe@test.com\"})"))
                 }
             }
             on("print normal") {
-                it("should print (user: {\\\"name\\\": \\\"John Doe\\\", \\\"email\\\": \\\"john.doe@test.com\\\"})") {
-                    assertThat(node.print(false, 0), equalTo("(user: {\\\"name\\\": \\\"John Doe\\\", \\\"email\\\": \\\"john.doe@test.com\\\"})"))
+                it("should print (user: {name: \\\"John Doe\\\", email: \\\"john.doe@test.com\\\"})") {
+                    assertThat(node.print(false, true, 0), equalTo("(user: {name: \\\"John Doe\\\", email: \\\"john.doe@test.com\\\"})"))
                 }
             }
         }
@@ -98,13 +98,13 @@ class GraphQLPrintSpek : Spek({
             val user2 = mapOf("name" to "user2", "email" to "user2@test.com")
             val node = Argument(mapOf("users" to listOf(user1, user2)))
             on("print pretty") {
-                it("should print (users: [{\"name\": \"user1\", \"email\": \"user1@test.com\"}, {\"name\": \"user2\", \"email\": \"user2@test.com\"}])") {
-                    assertThat(node.print(true, 0), equalTo("(users: [{\"name\": \"user1\", \"email\": \"user1@test.com\"}, {\"name\": \"user2\", \"email\": \"user2@test.com\"}])"))
+                it("should print (users: [{name: \"user1\", email: \"user1@test.com\"}, {name: \"user2\", email: \"user2@test.com\"}])") {
+                    assertThat(node.print(true, false, 0), equalTo("(users: [{name: \"user1\", email: \"user1@test.com\"}, {name: \"user2\", email: \"user2@test.com\"}])"))
                 }
             }
             on("print normal") {
-                it("should print (users: [{\\\"name\\\": \\\"user1\\\", \\\"email\\\": \\\"user1@test.com\\\"}, {\\\"name\": \\\"user2\\\", \\\"email\\\": \\\"user2@test.com\\\"}])") {
-                    assertThat(node.print(false, 0), equalTo("(users: [{\\\"name\\\": \\\"user1\\\", \\\"email\\\": \\\"user1@test.com\\\"}, {\\\"name\\\": \\\"user2\\\", \\\"email\\\": \\\"user2@test.com\\\"}])"))
+                it("should print (users: [{name: \\\"user1\\\", email: \\\"user1@test.com\\\"}, {name: \\\"user2\\\", email: \\\"user2@test.com\\\"}])") {
+                    assertThat(node.print(false, true, 0), equalTo("(users: [{name: \\\"user1\\\", email: \\\"user1@test.com\\\"}, {name: \\\"user2\\\", email: \\\"user2@test.com\\\"}])"))
                 }
             }
         }
@@ -115,12 +115,12 @@ class GraphQLPrintSpek : Spek({
             val node = SelectionSet(fields)
             on("print pretty") {
                 it("should print {\n  id\n  title\n}") {
-                    assertThat(node.print(true, 0), equalTo("{\n  id\n  title\n}"))
+                    assertThat(node.print(true, false, 0), equalTo("{\n  id\n  title\n}"))
                 }
             }
             on("print normal") {
                 it("should print {id title}") {
-                    assertThat(node.print(false, 0), equalTo("{ id title }"))
+                    assertThat(node.print(false, false, 0), equalTo("{ id title }"))
                 }
             }
         }
@@ -131,12 +131,12 @@ class GraphQLPrintSpek : Spek({
             val node = SelectionSet(fields)
             on("print pretty") {
                 it("should print {\n  id\n  title\n  assignee {\n    name\n    email\n  }\n}") {
-                    assertThat(node.print(true, 0), equalTo("{\n  id\n  title\n  assignee {\n    name\n    email\n  }\n}"))
+                    assertThat(node.print(true, false, 0), equalTo("{\n  id\n  title\n  assignee {\n    name\n    email\n  }\n}"))
                 }
             }
             on("print normal") {
                 it("should print { id title assignee { name email } }") {
-                    assertThat(node.print(false, 0), equalTo("{ id title assignee { name email } }"))
+                    assertThat(node.print(false, false, 0), equalTo("{ id title assignee { name email } }"))
                 }
             }
         }
@@ -148,12 +148,12 @@ class GraphQLPrintSpek : Spek({
             val node = Mutation("registerUser", argNode, setNode)
             on("print pretty") {
                 it("should print registerUser(input: { email: \"abcd@efgh.com\", password: \"abcd1234\" }){\n  id\n  token\n}") {
-                    assertThat(node.print(true, 0), equalTo("registerUser(input: { email: \"abcd@efgh.com\", password: \"abcd1234\" }) {\n  id\n  token\n}"))
+                    assertThat(node.print(true, false, 0), equalTo("registerUser (input: { email: \"abcd@efgh.com\", password: \"abcd1234\" }) {\n  id\n  token\n}"))
                 }
             }
             on("print normal") {
                 it("should print registerUser(input: { email: \\\"abcd@efgh.com\\\", password: \\\"abcd1234\\\" }){ id token }") {
-                    assertThat(node.print(false, 0), equalTo("registerUser(input: { email: \\\"abcd@efgh.com\\\", password: \\\"abcd1234\\\" }) { id token }"))
+                    assertThat(node.print(false, true, 0), equalTo("registerUser (input: { email: \\\"abcd@efgh.com\\\", password: \\\"abcd1234\\\" }) { id token }"))
                 }
             }
         }
@@ -163,12 +163,12 @@ class GraphQLPrintSpek : Spek({
             val node = Field("id")
             on("print pretty") {
                 it("should print id") {
-                    assertThat(node.print(true, 0), equalTo("id"))
+                    assertThat(node.print(true, false, 0), equalTo("id"))
                 }
             }
             on("print normal") {
                 it("should print id") {
-                    assertThat(node.print(false, 0), equalTo("id"))
+                    assertThat(node.print(false, false, 0), equalTo("id"))
                 }
             }
         }
@@ -177,12 +177,12 @@ class GraphQLPrintSpek : Spek({
             val node = Field("avatarSize", arguments = argNode)
             on("print pretty") {
                 it("should print avatarSize(size: 20)") {
-                    assertThat(node.print(true, 0), equalTo("avatarSize(size: 20)"))
+                    assertThat(node.print(true, false, 0), equalTo("avatarSize (size: 20)"))
                 }
             }
             on("print normal") {
                 it("should print avatarSize(size: 20)") {
-                    assertThat(node.print(false, 0), equalTo("avatarSize(size: 20)"))
+                    assertThat(node.print(false, false, 0), equalTo("avatarSize (size: 20)"))
                 }
             }
         }
@@ -191,12 +191,12 @@ class GraphQLPrintSpek : Spek({
             val node = Field("assignee", selectionSet = setNode)
             on("print pretty") {
                 it("should print assignee {\n  name\n  email\n}") {
-                    assertThat(node.print(true, 0), equalTo("assignee {\n  name\n  email\n}"))
+                    assertThat(node.print(true, false, 0), equalTo("assignee {\n  name\n  email\n}"))
                 }
             }
             on("print normal") {
                 it("should print assignee { name email }") {
-                    assertThat(node.print(false, 0), equalTo("assignee { name email }"))
+                    assertThat(node.print(false, false, 0), equalTo("assignee { name email }"))
                 }
             }
         }
@@ -206,12 +206,12 @@ class GraphQLPrintSpek : Spek({
             val node = Field("user", argNode, setNode)
             on("print pretty") {
                 it("should print user(id: 10) {\n  name\n  email\n") {
-                    assertThat(node.print(true, 0), equalTo("user(id: 10) {\n  name\n  email\n}"))
+                    assertThat(node.print(true, false, 0), equalTo("user (id: 10) {\n  name\n  email\n}"))
                 }
             }
             on("print normal") {
                 it("should print user(id: 10) { name email }") {
-                    assertThat(node.print(false, 0), equalTo("user(id: 10) { name email }"))
+                    assertThat(node.print(false, false, 0), equalTo("user (id: 10) { name email }"))
                 }
             }
         }
@@ -221,12 +221,12 @@ class GraphQLPrintSpek : Spek({
             val node = Operation(OperationType.QUERY, SelectionSet(listOf(Field("id"))))
             on("print pretty") {
                 it("should print query {\n  id\n}") {
-                    assertThat(node.print(true, 0), equalTo("query {\n  id\n}"))
+                    assertThat(node.print(true, false, 0), equalTo("query {\n  id\n}"))
                 }
             }
             on("print normal") {
                 it("should print query { id }") {
-                    assertThat(node.print(false, 0), equalTo("query { id }"))
+                    assertThat(node.print(false, false, 0), equalTo("query { id }"))
                 }
             }
         }
@@ -234,12 +234,12 @@ class GraphQLPrintSpek : Spek({
             val node = Operation(OperationType.QUERY, name = "getTask", selectionSet = SelectionSet(listOf(Field("id"))))
             on("print pretty") {
                 it("should print query getTask {\n  id\n}") {
-                    assertThat(node.print(true, 0), equalTo("query getTask {\n  id\n}"))
+                    assertThat(node.print(true, false, 0), equalTo("query getTask {\n  id\n}"))
                 }
             }
             on("print normal") {
                 it("should print query getTask { id }") {
-                    assertThat(node.print(false, 0), equalTo("query getTask { id }"))
+                    assertThat(node.print(false, false, 0), equalTo("query getTask { id }"))
                 }
             }
         }
@@ -248,12 +248,12 @@ class GraphQLPrintSpek : Spek({
             val node = Operation(OperationType.QUERY, name = "getTask", arguments = argNode, selectionSet= SelectionSet(listOf(Field("title"))))
             on("print pretty") {
                 it("should print query getTask(id: 1234) {\n  title\n}") {
-                    assertThat(node.print(true, 0), equalTo("query getTask(id: 1234) {\n  title\n}"))
+                    assertThat(node.print(true, false, 0), equalTo("query getTask (id: 1234) {\n  title\n}"))
                 }
             }
             on("print normal") {
                 it("should print query getTask(id: 1234) { title }") {
-                    assertThat(node.print(false, 0), equalTo("query getTask(id: 1234) { title }"))
+                    assertThat(node.print(false, false, 0), equalTo("query getTask (id: 1234) { title }"))
                 }
             }
         }
@@ -264,12 +264,12 @@ class GraphQLPrintSpek : Spek({
             val node = Document(queryNode)
             on("print pretty") {
                 it("should print document {\"query\":\"query { id }\", \"variables\": null, \"operationName\": null}") {
-                    assertThat(node.print(true, 0), equalTo("{\"query\": \"query {\n  id\n}\", \"variables\": null, \"operationName\": null}"))
+                    assertThat(node.print(true, false, 0), equalTo("{\"query\": \"query {\n  id\n}\", \"variables\": null, \"operationName\": null}"))
                 }
             }
             on("print normal") {
                 it("should print document {\"query\":\"query { id }\", \"variables\": null, \"operationName\": null}") {
-                    assertThat(node.print(false, 0), equalTo("{\"query\": \"query { id }\", \"variables\": null, \"operationName\": null}"))
+                    assertThat(node.print(false, false, 0), equalTo("{\"query\": \"query { id }\", \"variables\": null, \"operationName\": null}"))
                 }
             }
         }
@@ -278,12 +278,12 @@ class GraphQLPrintSpek : Spek({
             val node = Document(queryNode)
             on("print pretty") {
                 it("should print document {\"query\":\"query getAllTasks { id }\", \"variables\": null, \"operationName\": \"getAllTasks\"}") {
-                    assertThat(node.print(true, 0), equalTo("{\"query\": \"query getAllTasks {\n  id\n}\", \"variables\": null, \"operationName\": \"getAllTasks\"}"))
+                    assertThat(node.print(true, false, 0), equalTo("{\"query\": \"query getAllTasks {\n  id\n}\", \"variables\": null, \"operationName\": \"getAllTasks\"}"))
                 }
             }
             on("print normal") {
                 it("should print document {\"query\":\"query getAllTasks { id }\", \"variables\": null, \"operationName\": \"getAllTasks\"}") {
-                    assertThat(node.print(false, 0), equalTo("{\"query\": \"query getAllTasks { id }\", \"variables\": null, \"operationName\": \"getAllTasks\"}"))
+                    assertThat(node.print(false, false, 0), equalTo("{\"query\": \"query getAllTasks { id }\", \"variables\": null, \"operationName\": \"getAllTasks\"}"))
                 }
             }
         }

--- a/core/src/test/kotlin/me/lazmaid/kraph/test/GraphQLPrintSpek.kt
+++ b/core/src/test/kotlin/me/lazmaid/kraph/test/GraphQLPrintSpek.kt
@@ -102,9 +102,9 @@ class GraphQLPrintSpek : Spek({
                     assertThat(node.print(true, 0), equalTo("(users: [{\"name\": \"user1\", \"email\": \"user1@test.com\"}, {\"name\": \"user2\", \"email\": \"user2@test.com\"}])"))
                 }
             }
-            on("print pretty") {
+            on("print normal") {
                 it("should print (users: [{\\\"name\\\": \\\"user1\\\", \\\"email\\\": \\\"user1@test.com\\\"}, {\\\"name\": \\\"user2\\\", \\\"email\\\": \\\"user2@test.com\\\"}])") {
-                    assertThat(node.print(false, 0), equalTo("(users: [{\\\"name\\\": \\\"user1\\\", \\\"email\": \\\"user1@test.com\\\"}, {\\\"name\\\": \\\"user2\\\", \\\"email\\\": \\\"user2@test.com\\\"}])"))
+                    assertThat(node.print(false, 0), equalTo("(users: [{\\\"name\\\": \\\"user1\\\", \\\"email\\\": \\\"user1@test.com\\\"}, {\\\"name\\\": \\\"user2\\\", \\\"email\\\": \\\"user2@test.com\\\"}])"))
                 }
             }
         }
@@ -120,7 +120,7 @@ class GraphQLPrintSpek : Spek({
             }
             on("print normal") {
                 it("should print {id title}") {
-                    assertThat(node.print(false, 0), equalTo("{\\nid\\ntitle\\n}"))
+                    assertThat(node.print(false, 0), equalTo("{ id title }"))
                 }
             }
         }
@@ -135,8 +135,8 @@ class GraphQLPrintSpek : Spek({
                 }
             }
             on("print normal") {
-                it("should print {\\nid\\ntitle\\nassignee {\\nname\\nemail\\n}\\n}") {
-                    assertThat(node.print(false, 0), equalTo("{\\nid\\ntitle\\nassignee {\\nname\\nemail\\n}\\n}"))
+                it("should print { id title assignee { name email } }") {
+                    assertThat(node.print(false, 0), equalTo("{ id title assignee { name email } }"))
                 }
             }
         }
@@ -153,7 +153,7 @@ class GraphQLPrintSpek : Spek({
             }
             on("print normal") {
                 it("should print registerUser(input: { email: \\\"abcd@efgh.com\\\", password: \\\"abcd1234\\\" }){ id token }") {
-                    assertThat(node.print(false, 0), equalTo("registerUser(input: { email: \\\"abcd@efgh.com\\\", password: \\\"abcd1234\\\" }) {\\nid\\ntoken\\n}"))
+                    assertThat(node.print(false, 0), equalTo("registerUser(input: { email: \\\"abcd@efgh.com\\\", password: \\\"abcd1234\\\" }) { id token }"))
                 }
             }
         }
@@ -195,8 +195,8 @@ class GraphQLPrintSpek : Spek({
                 }
             }
             on("print normal") {
-                it("should print assignee {\\nname\\nemail\\n}") {
-                    assertThat(node.print(false, 0), equalTo("assignee {\\nname\\nemail\\n}"))
+                it("should print assignee { name email }") {
+                    assertThat(node.print(false, 0), equalTo("assignee { name email }"))
                 }
             }
         }
@@ -210,8 +210,8 @@ class GraphQLPrintSpek : Spek({
                 }
             }
             on("print normal") {
-                it("should print user(id: 10) {\\nname\\nemail\\n}") {
-                    assertThat(node.print(false, 0), equalTo("user(id: 10) {\\nname\\nemail\\n}"))
+                it("should print user(id: 10) { name email }") {
+                    assertThat(node.print(false, 0), equalTo("user(id: 10) { name email }"))
                 }
             }
         }
@@ -225,8 +225,8 @@ class GraphQLPrintSpek : Spek({
                 }
             }
             on("print normal") {
-                it("should print query {\\nid\\n}") {
-                    assertThat(node.print(false, 0), equalTo("query {\\nid\\n}"))
+                it("should print query { id }") {
+                    assertThat(node.print(false, 0), equalTo("query { id }"))
                 }
             }
         }
@@ -238,8 +238,8 @@ class GraphQLPrintSpek : Spek({
                 }
             }
             on("print normal") {
-                it("should print query getTask {\\nid\\n}") {
-                    assertThat(node.print(false, 0), equalTo("query getTask {\\nid\\n}"))
+                it("should print query getTask { id }") {
+                    assertThat(node.print(false, 0), equalTo("query getTask { id }"))
                 }
             }
         }
@@ -252,8 +252,8 @@ class GraphQLPrintSpek : Spek({
                 }
             }
             on("print normal") {
-                it("should print query getTask(id: 1234) {\\ntitle\\n}") {
-                    assertThat(node.print(false, 0), equalTo("query getTask(id: 1234) {\\ntitle\\n}"))
+                it("should print query getTask(id: 1234) { title }") {
+                    assertThat(node.print(false, 0), equalTo("query getTask(id: 1234) { title }"))
                 }
             }
         }
@@ -269,7 +269,7 @@ class GraphQLPrintSpek : Spek({
             }
             on("print normal") {
                 it("should print document {\"query\":\"query { id }\", \"variables\": null, \"operationName\": null}") {
-                    assertThat(node.print(false, 0), equalTo("{\"query\": \"query {\\nid\\n}\", \"variables\": null, \"operationName\": null}"))
+                    assertThat(node.print(false, 0), equalTo("{\"query\": \"query { id }\", \"variables\": null, \"operationName\": null}"))
                 }
             }
         }
@@ -283,7 +283,7 @@ class GraphQLPrintSpek : Spek({
             }
             on("print normal") {
                 it("should print document {\"query\":\"query getAllTasks { id }\", \"variables\": null, \"operationName\": \"getAllTasks\"}") {
-                    assertThat(node.print(false, 0), equalTo("{\"query\": \"query getAllTasks {\\nid\\n}\", \"variables\": null, \"operationName\": \"getAllTasks\"}"))
+                    assertThat(node.print(false, 0), equalTo("{\"query\": \"query getAllTasks { id }\", \"variables\": null, \"operationName\": \"getAllTasks\"}"))
                 }
             }
         }

--- a/core/src/test/kotlin/me/lazmaid/kraph/test/GraphQLPrintSpek.kt
+++ b/core/src/test/kotlin/me/lazmaid/kraph/test/GraphQLPrintSpek.kt
@@ -12,278 +12,219 @@ import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.api.dsl.on
 
 class GraphQLPrintSpek : Spek({
-
-    describe("Argument print function") {
-        given("id as argument and value as 1") {
-            val node = Argument(mapOf("id" to 1))
-            on("print pretty") {
-                it("should print (id: 1)") {
-                    assertThat(node.print(true, false, 0), equalTo("(id: 1)"))
+    data class Expectation(val normal: String, val pretty: String, val json: String)
+    describe("Argument") {
+        val tests = listOf(
+            Triple(
+                mapOf("id" to 1),
+                "a single number argument",
+                Expectation("(id: 1)", "(id: 1)", "(id: 1)")
+            ),
+            Triple(
+                mapOf("money" to 123.45),
+                "a single decimal argument",
+                Expectation("(money: 123.45)", "(money: 123.45)", "(money: 123.45)")
+            ),
+            Triple(
+                mapOf("isCancel" to false),
+                "a single boolean argument",
+                Expectation("(isCancel: false)", "(isCancel: false)", "(isCancel: false)")
+            ),
+            Triple(
+                mapOf("id" to 1, "title" to "Kraph"),
+                "a number and a string argument",
+                Expectation(
+                    "(id: 1, title: \"Kraph\")",
+                    "(id: 1, title: \"Kraph\")",
+                    "(id: 1, title: \\\"Kraph\\\")"
+                )
+            ),
+            Triple(
+                mapOf("user" to mapOf("name" to "John Doe", "email" to "john.doe@test.com")),
+                "an object argument",
+                Expectation(
+                    "(user: {name: \"John Doe\", email: \"john.doe@test.com\"})",
+                    "(user: {name: \"John Doe\", email: \"john.doe@test.com\"})",
+                    "(user: {name: \\\"John Doe\\\", email: \\\"john.doe@test.com\\\"})"
+                )
+            ),
+            Triple(
+                mapOf("users" to
+                    listOf(
+                        mapOf("name" to "user1", "email" to "user1@test.com"),
+                        mapOf("name" to "user2", "email" to "user2@test.com")
+                    )
+                ),
+                "an array of objects argument",
+                Expectation(
+                    "(users: [{name: \"user1\", email: \"user1@test.com\"}, {name: \"user2\", email: \"user2@test.com\"}])",
+                    "(users: [{name: \"user1\", email: \"user1@test.com\"}, {name: \"user2\", email: \"user2@test.com\"}])",
+                    "(users: [{name: \\\"user1\\\", email: \\\"user1@test.com\\\"}, {name: \\\"user2\\\", email: \\\"user2@test.com\\\"}])"
+                )
+            )
+        )
+        for((args, title, expectation) in tests) {
+            val arguments = Argument(args)
+            given(title) {
+                it("should print correctly in NORMAL mode") {
+                    assertThat(arguments.print(PrintFormat.NORMAL, 0), equalTo(expectation.normal))
                 }
-            }
-            on("print normal") {
-                it("should print (id: 1)") {
-                    assertThat(node.print(false, false, 0), equalTo("(id: 1)"))
+                it("should print correctly in PRETTY mode") {
+                    assertThat(arguments.print(PrintFormat.PRETTY, 0), equalTo(expectation.pretty))
                 }
-            }
-        }
-        given("money as argument and value as 123.45") {
-            val node = Argument(mapOf("money" to 123.45))
-            on("print pretty") {
-                it("should print (money: 123.45)") {
-                    assertThat(node.print(true, false, 0), equalTo("(money: 123.45)"))
-                }
-            }
-            on("print normal") {
-                it("should print (money: 123.45)") {
-                    assertThat(node.print(false, false, 0), equalTo("(money: 123.45)"))
-                }
-            }
-        }
-        given("isCancel as argument and value as false") {
-            val node = Argument(mapOf("isCancel" to false))
-            on("print pretty") {
-                it("should print (isCancel: false)") {
-                    assertThat(node.print(true, false, 0), equalTo("(isCancel: false)"))
-                }
-            }
-            on("print normal") {
-                it("should print (isCancel: false)") {
-                    assertThat(node.print(false, false, 0), equalTo("(isCancel: false)"))
-                }
-            }
-        }
-        given("id and title as arguments and value as 1 and Kraph") {
-            val node = Argument(mapOf("id" to 1, "title" to "Kraph"))
-            on("print pretty") {
-                it("should print (id: 1, title: \"Kraph\")") {
-                    assertThat(node.print(true, false, 0), equalTo("(id: 1, title: \"Kraph\")"))
-                }
-            }
-            on("print normal") {
-                it("should print (id: 1, title: \\\"Kraph\\\")") {
-                    assertThat(node.print(false, true, 0), equalTo("(id: 1, title: \\\"Kraph\\\")"))
-                }
-            }
-        }
-        given("an array of string as argument") {
-            val node = Argument(mapOf("titles" to listOf("title1", "title2")))
-            on("print pretty") {
-                it("should print (titles: [\"title1\", \"title2\"]") {
-                    assertThat(node.print(true, false, 0), equalTo("(titles: [\"title1\", \"title2\"])"))
-                }
-            }
-            on("print normal") {
-                it("should print (titles: [\\\"title1\\\", \\\"title2\\\"]") {
-                    assertThat(node.print(false, true, 0), equalTo("(titles: [\\\"title1\\\", \\\"title2\\\"])"))
-                }
-            }
-        }
-        given("a user object as argument") {
-            val user = mapOf("name" to "John Doe", "email" to "john.doe@test.com")
-            val node = Argument(mapOf("user" to user))
-            on("print pretty") {
-                it("should print (user: {name: \"John Doe\", email: \"john.doe@test.com\"})") {
-                    assertThat(node.print(true, false, 0), equalTo("(user: {name: \"John Doe\", email: \"john.doe@test.com\"})"))
-                }
-            }
-            on("print normal") {
-                it("should print (user: {name: \\\"John Doe\\\", email: \\\"john.doe@test.com\\\"})") {
-                    assertThat(node.print(false, true, 0), equalTo("(user: {name: \\\"John Doe\\\", email: \\\"john.doe@test.com\\\"})"))
-                }
-            }
-        }
-        given("an array of user object as argument") {
-            val user1 = mapOf("name" to "user1", "email" to "user1@test.com")
-            val user2 = mapOf("name" to "user2", "email" to "user2@test.com")
-            val node = Argument(mapOf("users" to listOf(user1, user2)))
-            on("print pretty") {
-                it("should print (users: [{name: \"user1\", email: \"user1@test.com\"}, {name: \"user2\", email: \"user2@test.com\"}])") {
-                    assertThat(node.print(true, false, 0), equalTo("(users: [{name: \"user1\", email: \"user1@test.com\"}, {name: \"user2\", email: \"user2@test.com\"}])"))
-                }
-            }
-            on("print normal") {
-                it("should print (users: [{name: \\\"user1\\\", email: \\\"user1@test.com\\\"}, {name: \\\"user2\\\", email: \\\"user2@test.com\\\"}])") {
-                    assertThat(node.print(false, true, 0), equalTo("(users: [{name: \\\"user1\\\", email: \\\"user1@test.com\\\"}, {name: \\\"user2\\\", email: \\\"user2@test.com\\\"}])"))
+                it("should print correctly in JSON mode") {
+                    assertThat(arguments.print(PrintFormat.JSON, 0), equalTo(expectation.json))
                 }
             }
         }
     }
-    describe("SelectionSet print function") {
-        given("two fields; id and title") {
-            val fields = listOf(Field("id"), Field("title"))
-            val node = SelectionSet(fields)
-            on("print pretty") {
-                it("should print {\n  id\n  title\n}") {
-                    assertThat(node.print(true, false, 0), equalTo("{\n  id\n  title\n}"))
+    describe("SelectionSet") {
+        val tests = listOf(
+            Triple(
+                listOf(Field("id"), Field("title")),
+                "two fields; id and title",
+                Expectation(
+                    "{ id title }",
+                    "{\n  id\n  title\n}",
+                    "{ id title }"
+                )
+            ),
+            Triple(
+                listOf(Field("id"), Field("title"), Field("assignee", selectionSet = SelectionSet(listOf(Field("name"), Field("email"))))),
+                "three fields; id, title, and assignee which contains name and email",
+                Expectation(
+                    "{ id title assignee { name email } }",
+                    "{\n  id\n  title\n  assignee {\n    name\n    email\n  }\n}",
+                    "{ id title assignee { name email } }"
+                )
+            )
+            // TODO: add tests for fragment syntax once fragments use GraphQL fragments
+        )
+        for((args, title, expectation) in tests) {
+            val selectionSet = SelectionSet(args)
+            given(title) {
+                it("should print correctly in NORMAL mode") {
+                    assertThat(selectionSet.print(PrintFormat.NORMAL, 0), equalTo(expectation.normal))
                 }
-            }
-            on("print normal") {
-                it("should print {id title}") {
-                    assertThat(node.print(false, false, 0), equalTo("{ id title }"))
+                it("should print correctly in PRETTY mode") {
+                    assertThat(selectionSet.print(PrintFormat.PRETTY, 0), equalTo(expectation.pretty))
                 }
-            }
-        }
-        given("three fields; id, title, and assignee which contains name and email") {
-            val assigneeSet = SelectionSet(listOf(Field("name"), Field("email")))
-            val assigneeField = Field("assignee", selectionSet = assigneeSet)
-            val fields = listOf(Field("id"), Field("title"), assigneeField)
-            val node = SelectionSet(fields)
-            on("print pretty") {
-                it("should print {\n  id\n  title\n  assignee {\n    name\n    email\n  }\n}") {
-                    assertThat(node.print(true, false, 0), equalTo("{\n  id\n  title\n  assignee {\n    name\n    email\n  }\n}"))
-                }
-            }
-            on("print normal") {
-                it("should print { id title assignee { name email } }") {
-                    assertThat(node.print(false, false, 0), equalTo("{ id title assignee { name email } }"))
+                it("should print correctly in JSON mode") {
+                    assertThat(selectionSet.print(PrintFormat.JSON, 0), equalTo(expectation.json))
                 }
             }
         }
     }
-    describe("Mutation print function") {
-        given("name registerUser with email and password as argument and payload contains id and token") {
+    describe("Mutation") {
+        given("name RegisterUser with email and password as argument and payload contains id and token") {
             val argNode = InputArgument(mapOf("email" to "abcd@efgh.com", "password" to "abcd1234"))
             val setNode = SelectionSet(listOf(Field("id"), Field("token")))
-            val node = Mutation("registerUser", argNode, setNode)
-            on("print pretty") {
-                it("should print registerUser(input: { email: \"abcd@efgh.com\", password: \"abcd1234\" }){\n  id\n  token\n}") {
-                    assertThat(node.print(true, false, 0), equalTo("registerUser (input: { email: \"abcd@efgh.com\", password: \"abcd1234\" }) {\n  id\n  token\n}"))
-                }
+            val node = Mutation("RegisterUser", argNode, setNode)
+            it("should print correctly in NORMAL mode") {
+                assertThat(node.print(PrintFormat.NORMAL, 0), equalTo("RegisterUser (input: { email: \"abcd@efgh.com\", password: \"abcd1234\" }) { id token }"))
             }
-            on("print normal") {
-                it("should print registerUser(input: { email: \\\"abcd@efgh.com\\\", password: \\\"abcd1234\\\" }){ id token }") {
-                    assertThat(node.print(false, true, 0), equalTo("registerUser (input: { email: \\\"abcd@efgh.com\\\", password: \\\"abcd1234\\\" }) { id token }"))
+            it("should print correctly in PRETTY mode") {
+                assertThat(node.print(PrintFormat.PRETTY, 0), equalTo("RegisterUser (input: { email: \"abcd@efgh.com\", password: \"abcd1234\" }) {\n  id\n  token\n}"))
+            }
+            it("should print correctly in JSON mode") {
+                assertThat(node.print(PrintFormat.JSON, 0), equalTo("RegisterUser (input: { email: \\\"abcd@efgh.com\\\", password: \\\"abcd1234\\\" }) { id token }"))
+            }
+        }
+    }
+    describe("Field") {
+        val tests = listOf(
+            Triple(Field("id"), "name id", Expectation("id", "id", "id")),
+            Triple(
+                Field("avatarSize", Argument(mapOf("size" to 20))),
+                "name avatarSize and size argument with value as 20",
+                Expectation(
+                    "avatarSize (size: 20)",
+                    "avatarSize (size: 20)",
+                    "avatarSize (size: 20)"
+                )
+            ),
+            Triple(
+                Field("assignee", selectionSet = SelectionSet(listOf(Field("name"), Field("email")))),
+                "name assignee and containing name and email",
+                Expectation(
+                    "assignee { name email }",
+                    "assignee {\n  name\n  email\n}",
+                    "assignee { name email }"
+                )
+            ),
+            Triple(
+                Field("user", Argument(mapOf("id" to 10)), SelectionSet(listOf(Field("name"), Field("email")))),
+                "name user and id argument with value as 10 and containing name and email",
+                Expectation(
+                    "user (id: 10) { name email }",
+                    "user (id: 10) {\n  name\n  email\n}",
+                    "user (id: 10) { name email }"
+                )
+            )
+        )
+        for((field, title, expectation) in tests) {
+            given(title) {
+                it("should print correctly in NORMAL mode") {
+                    assertThat(field.print(PrintFormat.NORMAL, 0), equalTo(expectation.normal))
+                }
+                it("should print correctly in PRETTY mode") {
+                    assertThat(field.print(PrintFormat.PRETTY, 0), equalTo(expectation.pretty))
+                }
+                it("should print correctly in JSON mode") {
+                    assertThat(field.print(PrintFormat.JSON, 0), equalTo(expectation.json))
                 }
             }
         }
     }
-    describe("Field print function") {
-        given("name id") {
-            val node = Field("id")
-            on("print pretty") {
-                it("should print id") {
-                    assertThat(node.print(true, false, 0), equalTo("id"))
+    val tests = listOf(
+        Triple(
+            Operation(OperationType.QUERY, SelectionSet(listOf(Field("id")))),
+            "type query and a field named id",
+            Expectation(
+                "query { id }",
+                "query {\n  id\n}",
+                "query { id }"
+            )
+        ),
+        Triple(
+            Operation(OperationType.QUERY, name = "getTask", selectionSet = SelectionSet(listOf(Field("id")))),
+            "type query with name \"getTask\" and field id",
+            Expectation(
+                "query getTask { id }",
+                "query getTask {\n  id\n}",
+                "query getTask { id }"
+            )
+        ),
+        Triple(
+            Operation(OperationType.QUERY, name = "getTask", arguments = Argument(mapOf("id" to 1234)), selectionSet = SelectionSet(listOf(Field("title")))),
+            "type query with name \"getTask\" and id(1234) as argument and field title",
+            Expectation(
+                "query getTask (id: 1234) { title }",
+                "query getTask (id: 1234) {\n  title\n}",
+                "query getTask (id: 1234) { title }"
+            )
+        )
+    )
+    describe("Operation") {
+        for((operation, title, expectation) in tests) {
+            given(title) {
+                it("should print correctly in NORMAL mode") {
+                    assertThat(operation.print(PrintFormat.NORMAL, 0), equalTo(expectation.normal))
                 }
-            }
-            on("print normal") {
-                it("should print id") {
-                    assertThat(node.print(false, false, 0), equalTo("id"))
+                it("should print correctly in PRETTY mode") {
+                    assertThat(operation.print(PrintFormat.PRETTY, 0), equalTo(expectation.pretty))
                 }
-            }
-        }
-        given("name avatarSize and size argument with value as 20") {
-            val argNode = Argument(mapOf("size" to 20))
-            val node = Field("avatarSize", arguments = argNode)
-            on("print pretty") {
-                it("should print avatarSize(size: 20)") {
-                    assertThat(node.print(true, false, 0), equalTo("avatarSize (size: 20)"))
-                }
-            }
-            on("print normal") {
-                it("should print avatarSize(size: 20)") {
-                    assertThat(node.print(false, false, 0), equalTo("avatarSize (size: 20)"))
-                }
-            }
-        }
-        given("name assignee that contains name and email") {
-            val setNode = SelectionSet(listOf(Field("name"), Field("email")))
-            val node = Field("assignee", selectionSet = setNode)
-            on("print pretty") {
-                it("should print assignee {\n  name\n  email\n}") {
-                    assertThat(node.print(true, false, 0), equalTo("assignee {\n  name\n  email\n}"))
-                }
-            }
-            on("print normal") {
-                it("should print assignee { name email }") {
-                    assertThat(node.print(false, false, 0), equalTo("assignee { name email }"))
-                }
-            }
-        }
-        given("name user and id argument with value as 10 and contains name and email") {
-            val argNode = Argument(mapOf("id" to 10))
-            val setNode = SelectionSet(listOf(Field("name"), Field("email")))
-            val node = Field("user", argNode, setNode)
-            on("print pretty") {
-                it("should print user(id: 10) {\n  name\n  email\n") {
-                    assertThat(node.print(true, false, 0), equalTo("user (id: 10) {\n  name\n  email\n}"))
-                }
-            }
-            on("print normal") {
-                it("should print user(id: 10) { name email }") {
-                    assertThat(node.print(false, false, 0), equalTo("user (id: 10) { name email }"))
+                it("should print correctly in JSON mode") {
+                    assertThat(operation.print(PrintFormat.JSON, 0), equalTo(expectation.json))
                 }
             }
         }
     }
-    describe("Operation print function") {
-        given("query type and field named id") {
-            val node = Operation(OperationType.QUERY, SelectionSet(listOf(Field("id"))))
-            on("print pretty") {
-                it("should print query {\n  id\n}") {
-                    assertThat(node.print(true, false, 0), equalTo("query {\n  id\n}"))
-                }
-            }
-            on("print normal") {
-                it("should print query { id }") {
-                    assertThat(node.print(false, false, 0), equalTo("query { id }"))
-                }
-            }
-        }
-        given("query type with name \"getTask\" and field id") {
-            val node = Operation(OperationType.QUERY, name = "getTask", selectionSet = SelectionSet(listOf(Field("id"))))
-            on("print pretty") {
-                it("should print query getTask {\n  id\n}") {
-                    assertThat(node.print(true, false, 0), equalTo("query getTask {\n  id\n}"))
-                }
-            }
-            on("print normal") {
-                it("should print query getTask { id }") {
-                    assertThat(node.print(false, false, 0), equalTo("query getTask { id }"))
-                }
-            }
-        }
-        given("query type with name \"getTask\" and id(1234) as argument and field title") {
-            val argNode = Argument(mapOf("id" to 1234))
-            val node = Operation(OperationType.QUERY, name = "getTask", arguments = argNode, selectionSet= SelectionSet(listOf(Field("title"))))
-            on("print pretty") {
-                it("should print query getTask(id: 1234) {\n  title\n}") {
-                    assertThat(node.print(true, false, 0), equalTo("query getTask (id: 1234) {\n  title\n}"))
-                }
-            }
-            on("print normal") {
-                it("should print query getTask(id: 1234) { title }") {
-                    assertThat(node.print(false, false, 0), equalTo("query getTask (id: 1234) { title }"))
-                }
-            }
-        }
-    }
-    describe("Document print function") {
-        given("document with simple query") {
-            val queryNode = Operation(OperationType.QUERY, selectionSet = SelectionSet(listOf(Field("id"))))
-            val node = Document(queryNode)
-            on("print pretty") {
-                it("should print document {\"query\":\"query { id }\", \"variables\": null, \"operationName\": null}") {
-                    assertThat(node.print(true, false, 0), equalTo("{\"query\": \"query {\n  id\n}\", \"variables\": null, \"operationName\": null}"))
-                }
-            }
-            on("print normal") {
-                it("should print document {\"query\":\"query { id }\", \"variables\": null, \"operationName\": null}") {
-                    assertThat(node.print(false, false, 0), equalTo("{\"query\": \"query { id }\", \"variables\": null, \"operationName\": null}"))
-                }
-            }
-        }
-        given("document with query named getAllTasks") {
-            val queryNode = Operation(OperationType.QUERY, name = "getAllTasks", selectionSet = SelectionSet(listOf(Field("id"))))
-            val node = Document(queryNode)
-            on("print pretty") {
-                it("should print document {\"query\":\"query getAllTasks { id }\", \"variables\": null, \"operationName\": \"getAllTasks\"}") {
-                    assertThat(node.print(true, false, 0), equalTo("{\"query\": \"query getAllTasks {\n  id\n}\", \"variables\": null, \"operationName\": \"getAllTasks\"}"))
-                }
-            }
-            on("print normal") {
-                it("should print document {\"query\":\"query getAllTasks { id }\", \"variables\": null, \"operationName\": \"getAllTasks\"}") {
-                    assertThat(node.print(false, false, 0), equalTo("{\"query\": \"query getAllTasks { id }\", \"variables\": null, \"operationName\": \"getAllTasks\"}"))
+    describe("Document") {
+        for((operation, title, expectation) in tests) {
+            given(title) {
+                it("should print always JSON format in the JSON wrapper") {
+                    assertThat(Document(operation).print(PrintFormat.NORMAL, 0), equalTo("{\"query\": \"${expectation.json}\", \"variables\": null, \"operationName\": ${operation.name?.let {"\"$it\""} ?: "null"}}"))
                 }
             }
         }

--- a/core/src/test/kotlin/me/lazmaid/kraph/test/RelayPrintSpek.kt
+++ b/core/src/test/kotlin/me/lazmaid/kraph/test/RelayPrintSpek.kt
@@ -5,6 +5,7 @@ import com.natpryce.hamkrest.equalTo
 import me.lazmaid.kraph.lang.Argument
 import me.lazmaid.kraph.lang.Field
 import me.lazmaid.kraph.lang.SelectionSet
+import me.lazmaid.kraph.lang.PrintFormat
 import me.lazmaid.kraph.lang.relay.CursorConnection
 import me.lazmaid.kraph.lang.relay.Edges
 import me.lazmaid.kraph.lang.relay.InputArgument
@@ -18,88 +19,175 @@ import org.jetbrains.spek.api.dsl.it
  * Created by VerachadW on 10/3/2016 AD.
  */
 class RelayPrintSpek : Spek({
-    describe("Relay InputArgument print function") {
-        given("id as argument and value as 1") {
-            val node = InputArgument(mapOf("id" to 1))
-            it("should print (input: { id: 1 })") {
-                assertThat(node.print(false, false, 0), equalTo("(input: { id: 1 })"))
-            }
-        }
-        given("name as argument and value as John Doe") {
-            val node = InputArgument(mapOf("name" to "John Doe"))
-            it("should print (input: { name: \\\"John Doe\\\" })") {
-                assertThat(node.print(false, true, 0), equalTo("(input: { name: \\\"John Doe\\\" })"))
-            }
-        }
-        given("name as argument and value as John Doe with pretty format enabled") {
-            val node = InputArgument(mapOf("name" to "John Doe"))
-            it("should print (input: { name: \"John Doe\" })") {
-                assertThat(node.print(true, false, 0), equalTo("(input: { name: \"John Doe\" })"))
+    data class Expectation(val normal: String, val pretty: String, val json: String)
+    describe("Relay InputArgument") {
+        val tests = listOf(
+            Triple(
+                mapOf("id" to 1),
+                "one number argument",
+                Expectation("(input: { id: 1 })", "(input: { id: 1 })", "(input: { id: 1 })")
+            ),
+            Triple(
+                mapOf("name" to "John Doe"),
+                "name string argument",
+                Expectation(
+                    "(input: { name: \"John Doe\" })",
+                    "(input: { name: \"John Doe\" })",
+                    "(input: { name: \\\"John Doe\\\" })"
+                )
+            )
+        )
+        for((args, title, expectation) in tests) {
+            val arguments = InputArgument(args)
+            given(title) {
+                it("should print correctly in NORMAL mode") {
+                    assertThat(arguments.print(PrintFormat.NORMAL, 0), equalTo(expectation.normal))
+                }
+                it("should print correctly in PRETTY mode") {
+                    assertThat(arguments.print(PrintFormat.PRETTY, 0), equalTo(expectation.pretty))
+                }
+                it("should print correctly in JSON mode") {
+                    assertThat(arguments.print(PrintFormat.JSON, 0), equalTo(expectation.json))
+                }
             }
         }
     }
-    describe("Relay Edges print function") {
-        given("edges with addtional field id") {
-            val node = Edges(SelectionSet(listOf(Field("title"))), additionalField = listOf(Field("id")))
-            it("should print edges { node { title } id }") {
-                assertThat(node.print(false, false, 0), equalTo("edges { node { title } id }"))
-            }
-        }
-        given("edges with id and title inside node object") {
-            val node = Edges(SelectionSet(listOf(Field("id"), Field("title"))))
-            it("should print edges { node { id title } }") {
-                assertThat(node.print(false, false, 0), equalTo("edges { node { id title } }"))
+    describe("Relay Edges") {
+        val tests = listOf(
+            Triple(
+                Edges(SelectionSet(listOf(Field("title"))), additionalField = listOf(Field("id"))),
+                "edges with addtional field id",
+                Expectation(
+                    "edges { node { title } id }",
+                    "edges {\n  node {\n    title\n  }\n  id\n}",
+                    "edges { node { title } id }"
+                )
+            ),
+            Triple(
+                Edges(SelectionSet(listOf(Field("id"), Field("title")))),
+                "edges with id and title inside node object",
+                Expectation(
+                    "edges { node { id title } }",
+                    "edges {\n  node {\n    id\n    title\n  }\n}",
+                    "edges { node { id title } }"
+                )
+            )
+        )
+        for((edge, title, expectation) in tests) {
+            given(title) {
+                it("should print correctly in NORMAL mode") {
+                    assertThat(edge.print(PrintFormat.NORMAL, 0), equalTo(expectation.normal))
+                }
+                it("should print correctly in PRETTY mode") {
+                    assertThat(edge.print(PrintFormat.PRETTY, 0), equalTo(expectation.pretty))
+                }
+                it("should print correctly in JSON mode") {
+                    assertThat(edge.print(PrintFormat.JSON, 0), equalTo(expectation.json))
+                }
             }
         }
     }
-    describe("Relay PageInfo print function") {
+    describe("Relay PageInfo") {
         given("default pageInfo with hasNextPage and hasPreviousPage") {
             val node = PageInfo(SelectionSet(listOf(Field("hasNextPage"),Field("hasPreviousPage"))))
-            it("should print pageInfo { hasNextPage hasPreviousPage }") {
-                assertThat(node.print(false, false, 0), equalTo("pageInfo { hasNextPage hasPreviousPage }"))
+            it("should print correctly in NORMAL mode") {
+                assertThat(node.print(PrintFormat.NORMAL, 0), equalTo("pageInfo { hasNextPage hasPreviousPage }"))
+            }
+            it("should print correctly in PRETTY mode") {
+                assertThat(node.print(PrintFormat.PRETTY, 0), equalTo("pageInfo {\n  hasNextPage\n  hasPreviousPage\n}"))
+            }
+            it("should print correctly in JSON mode") {
+                assertThat(node.print(PrintFormat.JSON, 0), equalTo("pageInfo { hasNextPage hasPreviousPage }"))
             }
         }
     }
-    describe("Relay Cursor Connection print function") {
-        given("cursor cursorConnection named notes with title in node object and only 10 items") {
-            val selectionSet = SelectionSet(listOf(Edges(SelectionSet(listOf(Field("title"))))))
-            val argsNode = Argument(mapOf("first" to 10))
-            val node = CursorConnection("notes", argsNode, selectionSet)
-            it("should print notes (first: 10) { edges { node { title } } }") {
-                assertThat(node.print(false, false, 0), equalTo("notes (first: 10) { edges { node { title } } }"))
-            }
-        }
-        given("cursor cursorConnection named notes with title in node object and only next 10 items after cursor named 'abcd1234'") {
-            val selectionSet = SelectionSet(listOf(Edges(SelectionSet(listOf(Field("title"))))))
-            val argsNode = Argument(mapOf("first" to 10, "after" to "abcd1234"))
-            val node = CursorConnection("notes", argsNode, selectionSet)
-            it("should print notes (first: 10, before: \"abcd1234\") { edges { node { title } } }") {
-                assertThat(node.print(false, true, 0), equalTo("notes (first: 10, after: \\\"abcd1234\\\") { edges { node { title } } }"))
-            }
-        }
-        given("cursor cursorConnection named notes with title in node object and only last 10 items") {
-            val selectionSet = SelectionSet(listOf(Edges(SelectionSet(listOf(Field("title"))))))
-            val argsNode = Argument(mapOf("last" to 10))
-            val node = CursorConnection("notes", argsNode, selectionSet)
-            it("should print notes (last: 10) { edges { node { title } } }") {
-                assertThat(node.print(false, false, 0), equalTo("notes (last: 10) { edges { node { title } } }"))
-            }
-        }
-        given("cursor cursorConnection named notes with title in node object and only last 10 items before cursor named 'abcd1234'") {
-            val selectionSet = SelectionSet(listOf(Edges(SelectionSet(listOf(Field("title"))))))
-            val argsNode = Argument(mapOf("last" to 10, "before" to "abcd1234"))
-            val node = CursorConnection("notes", argsNode, selectionSet)
-            it("should print notes (last: 10, before: \"abcd1234\") { edges { node { title } } }") {
-                assertThat(node.print(false, true, 0), equalTo("notes (last: 10, before: \\\"abcd1234\\\") { edges { node { title } } }"))
-            }
-        }
-        given("cursor cursorConnection named notes with PageInfo object") {
-            val pageNode = PageInfo(SelectionSet(listOf(Field("hasNextPage"), Field("hasPreviousPage"))))
-            val selectionSet = SelectionSet(listOf(Edges(SelectionSet(listOf(Field("title")))), pageNode))
-            val argsNode = Argument(mapOf("first" to 10))
-            val node = CursorConnection("notes", argsNode, selectionSet)
-            it("should print notes (first: 10) { edges { node { title } } pageInfo { hasNextPage hasPreviousPage } }") {
-                assertThat(node.print(false, false, 0), equalTo("notes (first: 10) { edges { node { title } } pageInfo { hasNextPage hasPreviousPage } }"))
+    describe("Relay Cursor Connection") {
+        val tests = listOf(
+            Triple(
+                CursorConnection(
+                    "notes",
+                    Argument(mapOf("first" to 10)),
+                    SelectionSet(listOf(Edges(SelectionSet(listOf(Field("title"))))))
+                ),
+                "name notes, title in node object, and only 10 items",
+                Expectation(
+                    "notes (first: 10) { edges { node { title } } }",
+                    "notes (first: 10) {\n  edges {\n    node {\n      title\n    }\n  }\n}",
+                    "notes (first: 10) { edges { node { title } } }"
+                )
+            ),
+            Triple(
+                CursorConnection(
+                    "notes",
+                    Argument(mapOf("first" to 10, "after" to "abcd1234")),
+                    SelectionSet(listOf(Edges(SelectionSet(listOf(Field("title"))))))
+                ),
+                "name notes, title in node object, and only next 10 items after 'abcd1234'",
+                Expectation(
+                    "notes (first: 10, after: \"abcd1234\") { edges { node { title } } }",
+                    "notes (first: 10, after: \"abcd1234\") {\n  edges {\n    node {\n      title\n    }\n  }\n}",
+                    "notes (first: 10, after: \\\"abcd1234\\\") { edges { node { title } } }"
+                )
+            ),
+            Triple(
+                CursorConnection(
+                    "notes",
+                    Argument(mapOf("last" to 10)),
+                    SelectionSet(listOf(Edges(SelectionSet(listOf(Field("title"))))))
+                ),
+                "name  notes, title in node object, and only last 10 items",
+                Expectation(
+                    "notes (last: 10) { edges { node { title } } }",
+                    "notes (last: 10) {\n  edges {\n    node {\n      title\n    }\n  }\n}",
+                    "notes (last: 10) { edges { node { title } } }"
+                )
+            ),
+            Triple(
+                CursorConnection(
+                    "notes",
+                    Argument(mapOf("last" to 10, "before" to "abcd1234")),
+                    SelectionSet(listOf(Edges(SelectionSet(listOf(Field("title"))))))
+                ),
+                "name notes with title in node object and only last 10 items before 'abcd1234'",
+                Expectation(
+                    "notes (last: 10, before: \"abcd1234\") { edges { node { title } } }",
+                    "notes (last: 10, before: \"abcd1234\") {\n  edges {\n    node {\n      title\n    }\n  }\n}",
+                    "notes (last: 10, before: \\\"abcd1234\\\") { edges { node { title } } }"
+                )
+            ),
+            Triple(
+                 CursorConnection(
+                     "notes",
+                     Argument(mapOf("first" to 10)),
+                     SelectionSet(
+                         listOf(
+                             Edges(SelectionSet(listOf(Field("title")))),
+                             PageInfo(SelectionSet(listOf(
+                                 Field("hasNextPage"),
+                                 Field("hasPreviousPage")
+                             )))
+                        )
+                    )
+                ),
+                "name notes and a PageInfo object",
+                Expectation(
+                    "notes (first: 10) { edges { node { title } } pageInfo { hasNextPage hasPreviousPage } }",
+                    "notes (first: 10) {\n  edges {\n    node {\n      title\n    }\n  }\n  pageInfo {\n    hasNextPage\n    hasPreviousPage\n  }\n}",
+                    "notes (first: 10) { edges { node { title } } pageInfo { hasNextPage hasPreviousPage } }"
+                )
+            )
+        )
+        for((cursor, title, expectation) in tests) {
+            given(title) {
+                it("should print correctly in NORMAL mode") {
+                    assertThat(cursor.print(PrintFormat.NORMAL, 0), equalTo(expectation.normal))
+                }
+                it("should print correctly in PRETTY mode") {
+                    assertThat(cursor.print(PrintFormat.PRETTY, 0), equalTo(expectation.pretty))
+                }
+                it("should print correctly in JSON mode") {
+                    assertThat(cursor.print(PrintFormat.JSON, 0), equalTo(expectation.json))
+                }
             }
         }
     }

--- a/core/src/test/kotlin/me/lazmaid/kraph/test/RelayPrintSpek.kt
+++ b/core/src/test/kotlin/me/lazmaid/kraph/test/RelayPrintSpek.kt
@@ -22,19 +22,19 @@ class RelayPrintSpek : Spek({
         given("id as argument and value as 1") {
             val node = InputArgument(mapOf("id" to 1))
             it("should print (input: { id: 1 })") {
-                assertThat(node.print(false, 0), equalTo("(input: { id: 1 })"))
+                assertThat(node.print(false, false, 0), equalTo("(input: { id: 1 })"))
             }
         }
         given("name as argument and value as John Doe") {
             val node = InputArgument(mapOf("name" to "John Doe"))
             it("should print (input: { name: \\\"John Doe\\\" })") {
-                assertThat(node.print(false, 0), equalTo("(input: { name: \\\"John Doe\\\" })"))
+                assertThat(node.print(false, true, 0), equalTo("(input: { name: \\\"John Doe\\\" })"))
             }
         }
         given("name as argument and value as John Doe with pretty format enabled") {
             val node = InputArgument(mapOf("name" to "John Doe"))
             it("should print (input: { name: \"John Doe\" })") {
-                assertThat(node.print(true, 0), equalTo("(input: { name: \"John Doe\" })"))
+                assertThat(node.print(true, false, 0), equalTo("(input: { name: \"John Doe\" })"))
             }
         }
     }
@@ -42,13 +42,13 @@ class RelayPrintSpek : Spek({
         given("edges with addtional field id") {
             val node = Edges(SelectionSet(listOf(Field("title"))), additionalField = listOf(Field("id")))
             it("should print edges { node { title } id }") {
-                assertThat(node.print(false, 0), equalTo("edges { node { title } id }"))
+                assertThat(node.print(false, false, 0), equalTo("edges { node { title } id }"))
             }
         }
         given("edges with id and title inside node object") {
             val node = Edges(SelectionSet(listOf(Field("id"), Field("title"))))
             it("should print edges { node { id title } }") {
-                assertThat(node.print(false, 0), equalTo("edges { node { id title } }"))
+                assertThat(node.print(false, false, 0), equalTo("edges { node { id title } }"))
             }
         }
     }
@@ -56,7 +56,7 @@ class RelayPrintSpek : Spek({
         given("default pageInfo with hasNextPage and hasPreviousPage") {
             val node = PageInfo(SelectionSet(listOf(Field("hasNextPage"),Field("hasPreviousPage"))))
             it("should print pageInfo { hasNextPage hasPreviousPage }") {
-                assertThat(node.print(false, 0), equalTo("pageInfo { hasNextPage hasPreviousPage }"))
+                assertThat(node.print(false, false, 0), equalTo("pageInfo { hasNextPage hasPreviousPage }"))
             }
         }
     }
@@ -65,32 +65,32 @@ class RelayPrintSpek : Spek({
             val selectionSet = SelectionSet(listOf(Edges(SelectionSet(listOf(Field("title"))))))
             val argsNode = Argument(mapOf("first" to 10))
             val node = CursorConnection("notes", argsNode, selectionSet)
-            it("should print notes(first: 10) { edges { node { title } } }") {
-                assertThat(node.print(false, 0), equalTo("notes(first: 10) { edges { node { title } } }"))
+            it("should print notes (first: 10) { edges { node { title } } }") {
+                assertThat(node.print(false, false, 0), equalTo("notes (first: 10) { edges { node { title } } }"))
             }
         }
         given("cursor cursorConnection named notes with title in node object and only next 10 items after cursor named 'abcd1234'") {
             val selectionSet = SelectionSet(listOf(Edges(SelectionSet(listOf(Field("title"))))))
             val argsNode = Argument(mapOf("first" to 10, "after" to "abcd1234"))
             val node = CursorConnection("notes", argsNode, selectionSet)
-            it("should print notes(first: 10, before: \"abcd1234\") { edges { node { title } } }") {
-                assertThat(node.print(false, 0), equalTo("notes(first: 10, after: \\\"abcd1234\\\") { edges { node { title } } }"))
+            it("should print notes (first: 10, before: \"abcd1234\") { edges { node { title } } }") {
+                assertThat(node.print(false, true, 0), equalTo("notes (first: 10, after: \\\"abcd1234\\\") { edges { node { title } } }"))
             }
         }
         given("cursor cursorConnection named notes with title in node object and only last 10 items") {
             val selectionSet = SelectionSet(listOf(Edges(SelectionSet(listOf(Field("title"))))))
             val argsNode = Argument(mapOf("last" to 10))
             val node = CursorConnection("notes", argsNode, selectionSet)
-            it("should print notes(last: 10) { edges { node { title } } }") {
-                assertThat(node.print(false, 0), equalTo("notes(last: 10) { edges { node { title } } }"))
+            it("should print notes (last: 10) { edges { node { title } } }") {
+                assertThat(node.print(false, false, 0), equalTo("notes (last: 10) { edges { node { title } } }"))
             }
         }
         given("cursor cursorConnection named notes with title in node object and only last 10 items before cursor named 'abcd1234'") {
             val selectionSet = SelectionSet(listOf(Edges(SelectionSet(listOf(Field("title"))))))
             val argsNode = Argument(mapOf("last" to 10, "before" to "abcd1234"))
             val node = CursorConnection("notes", argsNode, selectionSet)
-            it("should print notes(last: 10, before: \"abcd1234\") { edges { node { title } } }") {
-                assertThat(node.print(false, 0), equalTo("notes(last: 10, before: \\\"abcd1234\\\") { edges { node { title } } }"))
+            it("should print notes (last: 10, before: \"abcd1234\") { edges { node { title } } }") {
+                assertThat(node.print(false, true, 0), equalTo("notes (last: 10, before: \\\"abcd1234\\\") { edges { node { title } } }"))
             }
         }
         given("cursor cursorConnection named notes with PageInfo object") {
@@ -98,8 +98,8 @@ class RelayPrintSpek : Spek({
             val selectionSet = SelectionSet(listOf(Edges(SelectionSet(listOf(Field("title")))), pageNode))
             val argsNode = Argument(mapOf("first" to 10))
             val node = CursorConnection("notes", argsNode, selectionSet)
-            it("should print notes(first: 10) { edges { node { title } } pageInfo { hasNextPage hasPreviousPage } }") {
-                assertThat(node.print(false, 0), equalTo("notes(first: 10) { edges { node { title } } pageInfo { hasNextPage hasPreviousPage } }"))
+            it("should print notes (first: 10) { edges { node { title } } pageInfo { hasNextPage hasPreviousPage } }") {
+                assertThat(node.print(false, false, 0), equalTo("notes (first: 10) { edges { node { title } } pageInfo { hasNextPage hasPreviousPage } }"))
             }
         }
     }

--- a/core/src/test/kotlin/me/lazmaid/kraph/test/RelayPrintSpek.kt
+++ b/core/src/test/kotlin/me/lazmaid/kraph/test/RelayPrintSpek.kt
@@ -42,13 +42,13 @@ class RelayPrintSpek : Spek({
         given("edges with addtional field id") {
             val node = Edges(SelectionSet(listOf(Field("title"))), additionalField = listOf(Field("id")))
             it("should print edges { node { title } id }") {
-                assertThat(node.print(false, 0), equalTo("edges {\\nnode {\\ntitle\\n}\\nid\\n}"))
+                assertThat(node.print(false, 0), equalTo("edges { node { title } id }"))
             }
         }
         given("edges with id and title inside node object") {
             val node = Edges(SelectionSet(listOf(Field("id"), Field("title"))))
             it("should print edges { node { id title } }") {
-                assertThat(node.print(false, 0), equalTo("edges {\\nnode {\\nid\\ntitle\\n}\\n}"))
+                assertThat(node.print(false, 0), equalTo("edges { node { id title } }"))
             }
         }
     }
@@ -56,7 +56,7 @@ class RelayPrintSpek : Spek({
         given("default pageInfo with hasNextPage and hasPreviousPage") {
             val node = PageInfo(SelectionSet(listOf(Field("hasNextPage"),Field("hasPreviousPage"))))
             it("should print pageInfo { hasNextPage hasPreviousPage }") {
-                assertThat(node.print(false, 0), equalTo("pageInfo {\\nhasNextPage\\nhasPreviousPage\\n}"))
+                assertThat(node.print(false, 0), equalTo("pageInfo { hasNextPage hasPreviousPage }"))
             }
         }
     }
@@ -66,7 +66,7 @@ class RelayPrintSpek : Spek({
             val argsNode = Argument(mapOf("first" to 10))
             val node = CursorConnection("notes", argsNode, selectionSet)
             it("should print notes(first: 10) { edges { node { title } } }") {
-                assertThat(node.print(false, 0), equalTo("notes(first: 10) {\\nedges {\\nnode {\\ntitle\\n}\\n}\\n}"))
+                assertThat(node.print(false, 0), equalTo("notes(first: 10) { edges { node { title } } }"))
             }
         }
         given("cursor cursorConnection named notes with title in node object and only next 10 items after cursor named 'abcd1234'") {
@@ -74,7 +74,7 @@ class RelayPrintSpek : Spek({
             val argsNode = Argument(mapOf("first" to 10, "after" to "abcd1234"))
             val node = CursorConnection("notes", argsNode, selectionSet)
             it("should print notes(first: 10, before: \"abcd1234\") { edges { node { title } } }") {
-                assertThat(node.print(false, 0), equalTo("notes(first: 10, after: \\\"abcd1234\\\") {\\nedges {\\nnode {\\ntitle\\n}\\n}\\n}"))
+                assertThat(node.print(false, 0), equalTo("notes(first: 10, after: \\\"abcd1234\\\") { edges { node { title } } }"))
             }
         }
         given("cursor cursorConnection named notes with title in node object and only last 10 items") {
@@ -82,7 +82,7 @@ class RelayPrintSpek : Spek({
             val argsNode = Argument(mapOf("last" to 10))
             val node = CursorConnection("notes", argsNode, selectionSet)
             it("should print notes(last: 10) { edges { node { title } } }") {
-                assertThat(node.print(false, 0), equalTo("notes(last: 10) {\\nedges {\\nnode {\\ntitle\\n}\\n}\\n}"))
+                assertThat(node.print(false, 0), equalTo("notes(last: 10) { edges { node { title } } }"))
             }
         }
         given("cursor cursorConnection named notes with title in node object and only last 10 items before cursor named 'abcd1234'") {
@@ -90,7 +90,7 @@ class RelayPrintSpek : Spek({
             val argsNode = Argument(mapOf("last" to 10, "before" to "abcd1234"))
             val node = CursorConnection("notes", argsNode, selectionSet)
             it("should print notes(last: 10, before: \"abcd1234\") { edges { node { title } } }") {
-                assertThat(node.print(false, 0), equalTo("notes(last: 10, before: \\\"abcd1234\\\") {\\nedges {\\nnode {\\ntitle\\n}\\n}\\n}"))
+                assertThat(node.print(false, 0), equalTo("notes(last: 10, before: \\\"abcd1234\\\") { edges { node { title } } }"))
             }
         }
         given("cursor cursorConnection named notes with PageInfo object") {
@@ -99,7 +99,7 @@ class RelayPrintSpek : Spek({
             val argsNode = Argument(mapOf("first" to 10))
             val node = CursorConnection("notes", argsNode, selectionSet)
             it("should print notes(first: 10) { edges { node { title } } pageInfo { hasNextPage hasPreviousPage } }") {
-                assertThat(node.print(false, 0), equalTo("notes(first: 10) {\\nedges {\\nnode {\\ntitle\\n}\\n}\\npageInfo {\\nhasNextPage\\nhasPreviousPage\\n}\\n}"))
+                assertThat(node.print(false, 0), equalTo("notes(first: 10) { edges { node { title } } pageInfo { hasNextPage hasPreviousPage } }"))
             }
         }
     }

--- a/core/src/test/kotlin/me/lazmaid/kraph/test/RequestSpek.kt
+++ b/core/src/test/kotlin/me/lazmaid/kraph/test/RequestSpek.kt
@@ -16,21 +16,22 @@ import org.jetbrains.spek.api.dsl.it
 class RequestSpek : Spek({
     describe("Kraph Query Request format printers") {
         val query = Kraph {
-            query("GetUser") {
-                field("id")
+            query("GetUserId") {
+                field("user", mapOf("name" to "UserName")) {
+                    field("id")
+                }
             }
         }
-        // TODO: finish writing all these tests
         describe("#toRequestString") {
             given("document with simple query") {
                 it("should print the entire document") {
-                    assertThat(query.toRequestString(), equalTo("{\"query\": \"query GetUser { id }\", \"variables\": null, \"operationName\": \"GetUser\"}"))
+                    assertThat(query.toRequestString(), equalTo("{\"query\": \"query GetUserId { user (name: \\\"UserName\\\") { id } }\", \"variables\": null, \"operationName\": \"GetUserId\"}"))
                 }
             }
         }
         describe("#requestQueryString") {
             it("should print just the query portion of the document") {
-                assertThat(query.requestQueryString(), equalTo("query GetUser { id }"))
+                assertThat(query.requestQueryString(), equalTo("query GetUserId { user (name: \"UserName\") { id } }"))
             }
         }
         describe("#requestVariableString") {
@@ -38,8 +39,8 @@ class RequestSpek : Spek({
         }
         describe("#requestOperationName") {
             given("document with simple query") {
-                it("should print the name of the query in quotes") {
-                    assertThat(query.requestOperationName(), equalTo("\"GetUser\""))
+                it("should print the name of the query") {
+                    assertThat(query.requestOperationName(), equalTo("GetUserId"))
                 }
             }
         }

--- a/core/src/test/kotlin/me/lazmaid/kraph/test/RequestSpek.kt
+++ b/core/src/test/kotlin/me/lazmaid/kraph/test/RequestSpek.kt
@@ -1,0 +1,47 @@
+package me.lazmaid.kraph.test
+
+import com.natpryce.hamkrest.*
+import com.natpryce.hamkrest.assertion.assertThat
+import me.lazmaid.kraph.Kraph
+import me.lazmaid.kraph.NoFieldsInSelectionSetException
+import me.lazmaid.kraph.NoSuchFragmentException
+import me.lazmaid.kraph.lang.OperationType
+import me.lazmaid.kraph.lang.relay.CursorConnection
+import me.lazmaid.kraph.lang.relay.PageInfo
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.given
+import org.jetbrains.spek.api.dsl.it
+
+class RequestSpek : Spek({
+    describe("Kraph Query Request format printers") {
+        val query = Kraph {
+            query("GetUser") {
+                field("id")
+            }
+        }
+        // TODO: finish writing all these tests
+        describe("#toRequestString") {
+            given("document with simple query") {
+                it("should print the entire document") {
+                    assertThat(query.toRequestString(), equalTo("{\"query\": \"query GetUser {\\nid\\n}\", \"variables\": null, \"operationName\": \"GetUser\"}"))
+                }
+            }
+        }
+        describe("#requestQueryString") {
+            it("should print just the query portion of the document") {
+                assertThat(query.requestQueryString(), equalTo("query GetUser {\\nid\\n}"))
+            }
+        }
+        describe("#requestVariableString") {
+            // TODO: variables not yet implemented
+        }
+        describe("#requestOperationName") {
+            given("document with simple query") {
+                it("should print the name of the query in quotes") {
+                    assertThat(query.requestOperationName(), equalTo("\"GetUser\""))
+                }
+            }
+        }
+    }
+})

--- a/core/src/test/kotlin/me/lazmaid/kraph/test/RequestSpek.kt
+++ b/core/src/test/kotlin/me/lazmaid/kraph/test/RequestSpek.kt
@@ -24,13 +24,13 @@ class RequestSpek : Spek({
         describe("#toRequestString") {
             given("document with simple query") {
                 it("should print the entire document") {
-                    assertThat(query.toRequestString(), equalTo("{\"query\": \"query GetUser {\\nid\\n}\", \"variables\": null, \"operationName\": \"GetUser\"}"))
+                    assertThat(query.toRequestString(), equalTo("{\"query\": \"query GetUser { id }\", \"variables\": null, \"operationName\": \"GetUser\"}"))
                 }
             }
         }
         describe("#requestQueryString") {
             it("should print just the query portion of the document") {
-                assertThat(query.requestQueryString(), equalTo("query GetUser {\\nid\\n}"))
+                assertThat(query.requestQueryString(), equalTo("query GetUser { id }"))
             }
         }
         describe("#requestVariableString") {


### PR DESCRIPTION
Was having trouble sending GET requests with this properly as the only "query only" string was pretty printed, so I added some functions to break up that one for writing POST requests. Changed the output format a bit too, so it would be a bit more readable/standard looking. Seems to be working from my app, and fixed up the tests that had to change for this. 

Not sure why there are so many commits listed. Seems like a lot of the ones from the last PR. 