### PR TITLE
The fix bug with TR locale on android devices

### DIFF
--- a/core/src/main/kotlin/me/lazmaid/kraph/lang/Operation.kt
+++ b/core/src/main/kotlin/me/lazmaid/kraph/lang/Operation.kt
@@ -1,5 +1,6 @@
 package me.lazmaid.kraph.lang
 
+
 /**
  * Created by VerachadW on 10/2/2016 AD.
  */
@@ -16,7 +17,11 @@ internal class Operation(
     ): String {
         val namePart = name?.let{ " $it" } ?: ""
         val argumentPart = arguments?.print(format, previousLevel)?.let{ " $it" } ?: ""
-        return "${type.name.toLowerCase()}$namePart$argumentPart ${selectionSet.print(format, previousLevel)}"
+        val operationType = when(type) {
+            OperationType.QUERY -> "query"
+            OperationType.MUTATION -> "mutation"
+        }
+        return "$operationType$namePart$argumentPart ${selectionSet.print(format, previousLevel)}"
     }
 }
 


### PR DESCRIPTION
(cherry picked from commit fccf4111b17e5b679ca15be3fed3a7df37f397da)
Bugfix when use tr locale 

This bugfix. A user selects a Turkish locale on an android device and has the error. This example demonstrates trouble 
```
package com.github.test.error

import androidx.appcompat.app.AppCompatActivity
import android.os.Bundle
import android.util.Log
import java.util.*

internal enum class OperationType {
    QUERY,
    MUTATION
}

class MainActivity : AppCompatActivity() {

    override fun onCreate(savedInstanceState: Bundle?) {
        super.onCreate(savedInstanceState)
        setContentView(R.layout.activity_main)
        val trLocaleFromOsSettings = Locale("tr")
        val enLocaleSoSettings = Locale.ENGLISH
        val sTypeFromEnumField = OperationType.MUTATION.name.toLowerCase(trLocaleFromOsSettings)
        val sTypeFromString = "MUTATION".toLowerCase(trLocaleFromOsSettings)
        val sTypeFromInit = "mutation"
        Log.d("TEST", "LOCALE -> ${trLocaleFromOsSettings.language}")

        Log.d("TEST", "sTypeFromEnumField -> $sTypeFromEnumField")
        Log.d("TEST", "sTypeFromString -> $sTypeFromString")
        Log.d("TEST", "sTypeFromString -> $sTypeFromString")
        Log.d("TEST", "sTyleFromInit -> $sTypeFromInit")
        Log.d("TEST", "sTyleFromInit == sTypeFromString -> ${sTypeFromInit == sTypeFromString}")
        Log.d("TEST", "sTyleFromInit == sTypeFromString -> ${sTypeFromInit == sTypeFromEnumField}")
    }
}


```

Output:
```
06-17 17:00:31.166 27489-27489/? D/TEST: LOCALE -> tr
06-17 17:00:31.166 27489-27489/? D/TEST: sTypeFromEnumField -> mutatıon
06-17 17:00:31.166 27489-27489/? D/TEST: sTypeFromString -> mutatıon
06-17 17:00:31.166 27489-27489/? D/TEST: sTypeFromString -> mutatıon
06-17 17:00:31.166 27489-27489/? D/TEST: sTyleFromInit -> mutation
06-17 17:00:31.166 27489-27489/? D/TEST: sTyleFromInit == sTypeFromString -> false
06-17 17:00:31.166 27489-27489/? D/TEST: sTyleFromInit == sTypeFromString -> false
```

I didn't use Locale.ROOT since I want to avoid java dependencies



> Hi, Sorry for the very delay. If you can change your changes to develop it would be very appreciated.

so, I did it