### PR TITLE
Field objects are allowed to be supplied without declaring blocks

### DIFF
--- a/core/src/main/kotlin/me/lazmaid/kraph/Kraph.kt
+++ b/core/src/main/kotlin/me/lazmaid/kraph/Kraph.kt
@@ -51,7 +51,7 @@ class Kraph(f: Kraph.() -> Unit) {
     open inner class FieldBuilder {
         internal val fields = arrayListOf<Field>()
 
-        fun fieldObject(name: String, alias: String? = null, args: Map<String, Any>? = null, builder: FieldBlock) {
+        fun fieldObject(name: String, alias: String? = null, args: Map<String, Any>? = null, builder: FieldBlock? = null) {
             addField(name, alias, args, builder)
         }
 

--- a/core/src/test/kotlin/me/lazmaid/kraph/test/BuilderSpek.kt
+++ b/core/src/test/kotlin/me/lazmaid/kraph/test/BuilderSpek.kt
@@ -109,6 +109,21 @@ class BuilderSpek : Spek({
                 }, throws(noFieldInSelectionSetMessageMatcher("test")))
             }
         }
+        given("sample query with object and no supplied field builder") {
+            val query = Kraph {
+                query {
+                    fieldObject("test")
+                }
+            }
+            it("should not throw a NoFieldsInSelectionSetException and build the request correctly") {
+                assertThat(
+                    query.toRequestString(),
+                    equalTo(
+                        "{\"query\": \"query { test }\", \"variables\": null, \"operationName\": null}"
+                    )
+                )
+            }
+        }
         given("sample mutation") {
             val query = Kraph {
                 mutation {


### PR DESCRIPTION
GraphQL endpoints do not necessarily need to specify _fields_ as arguments when a `mutation` or `query` is received. Diverse implementations on the server-side will allow for returning non-standardized data formats, such as JSON, which breaks this library.

Fixes:  https://github.com/VerachadW/kraph/issues/31